### PR TITLE
Update links to contributing.md and code_of_conduct.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Each component has its own repository:
 * [Baggageclaim](https://github.com/concourse/baggageclaim) is a server for
   managing caches and artifacts on the workers
 
-You can get Concourse up and running on your local machine by following the Contributors guide in [`CONTRIBUTING.md`](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md)
+You can get Concourse up and running on your local machine by following the Contributors guide in [`CONTRIBUTING.md`](https://github.com/concourse/concourse-bosh-release/blob/master/CONTRIBUTING.md)
 
 To learn more about how they fit together, see [Concourse
 Architecture](https://concourse-ci.org/concepts.html).
 
 Please note that Concourse is released with a Contributor Code of Conduct.
 By participating in this project you agree to abide by its terms. You can review
-the Code of Code of Conduct in [`CODE_OF_CONDUCT.md`](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md) 
+the Code of Code of Conduct in [`CODE_OF_CONDUCT.md`](https://github.com/concourse/concourse-bosh-release/blob/master/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
The paths to the contributing.md and code_of_conduct.md do not currently link to the corresponding files. This PR updates the links to these.