### PR TITLE
modify env file permissions and ownership to 0600 / vcap:vcap

### DIFF
--- a/jobs/web/templates/pre_start.erb
+++ b/jobs/web/templates/pre_start.erb
@@ -8,6 +8,10 @@ mkdir -p /var/vcap/jobs/web/config/env
 <%
   # vim: ft=eruby
 
+  def env_file_perms(fn)
+    "chown vcap:vcap #{fn}\nchmod 0600 #{fn}\n"
+  end
+
   def env_file_content(v)
     case v
     when Array
@@ -25,14 +29,16 @@ mkdir -p /var/vcap/jobs/web/config/env
     case v
     when Array
       v.collect.with_index do |v, i|
-        "cat > #{path}_#{i} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n"
+        fn = "#{path}_#{i}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
       end.join("\n\n")
     when Hash
       v.collect do |k, v|
-        "cat > #{path}_#{k} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n"
+        fn = "#{path}_#{k}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
       end.join("\n\n")
     else
-      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n\n"
+      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(path)}\n"
     end
   end
 -%>

--- a/jobs/web/templates/pre_start.erb
+++ b/jobs/web/templates/pre_start.erb
@@ -3,13 +3,20 @@
 
 set -e -u -x
 
+ENV_FILE_OWNER=vcap
+
 mkdir -p /var/vcap/jobs/web/config/env
 
 <%
   # vim: ft=eruby
 
   def env_file_perms(fn)
-    "chown vcap:vcap #{fn}\nchmod 0600 #{fn}\n"
+    <<~EOS
+      if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+        chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} #{fn}
+      fi
+      chmod 0600 #{fn}
+    EOS
   end
 
   def env_file_content(v)

--- a/jobs/web/templates/pre_start.erb.tmpl
+++ b/jobs/web/templates/pre_start.erb.tmpl
@@ -3,4 +3,6 @@
 
 set -e -u -x
 
+ENV_FILE_OWNER=vcap
+
 {{template "create_env_files.erb.tmpl" .}}

--- a/jobs/worker/templates/pre_start.erb
+++ b/jobs/worker/templates/pre_start.erb
@@ -12,7 +12,12 @@ mkdir -p /var/vcap/jobs/worker/config/env
   # vim: ft=eruby
 
   def env_file_perms(fn)
-    "chown vcap:vcap #{fn}\nchmod 0600 #{fn}\n"
+    <<~EOS
+      if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+        chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} #{fn}
+      fi
+      chmod 0600 #{fn}
+    EOS
   end
 
   def env_file_content(v)

--- a/jobs/worker/templates/pre_start.erb
+++ b/jobs/worker/templates/pre_start.erb
@@ -11,6 +11,10 @@ mkdir -p /var/vcap/jobs/worker/config/env
 <%
   # vim: ft=eruby
 
+  def env_file_perms(fn)
+    "chown vcap:vcap #{fn}\nchmod 0600 #{fn}\n"
+  end
+
   def env_file_content(v)
     case v
     when Array
@@ -28,14 +32,16 @@ mkdir -p /var/vcap/jobs/worker/config/env
     case v
     when Array
       v.collect.with_index do |v, i|
-        "cat > #{path}_#{i} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n"
+        fn = "#{path}_#{i}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
       end.join("\n\n")
     when Hash
       v.collect do |k, v|
-        "cat > #{path}_#{k} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n"
+        fn = "#{path}_#{k}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
       end.join("\n\n")
     else
-      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n\n"
+      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(path)}\n"
     end
   end
 -%>

--- a/tmpl/create_env_files.erb.tmpl
+++ b/tmpl/create_env_files.erb.tmpl
@@ -3,6 +3,10 @@ mkdir -p /var/vcap/jobs/{{.Name}}/config/env
 <%
   # vim: ft=eruby
 
+  def env_file_perms(fn)
+    "chown vcap:vcap #{fn}\nchmod 0600 #{fn}\n"
+  end
+
   def env_file_content(v)
     case v
     when Array
@@ -20,14 +24,16 @@ mkdir -p /var/vcap/jobs/{{.Name}}/config/env
     case v
     when Array
       v.collect.with_index do |v, i|
-        "cat > #{path}_#{i} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n"
+        fn = "#{path}_#{i}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
       end.join("\n\n")
     when Hash
       v.collect do |k, v|
-        "cat > #{path}_#{k} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n"
+        fn = "#{path}_#{k}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
       end.join("\n\n")
     else
-      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n\n"
+      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(path)}\n"
     end
   end
 -%>

--- a/tmpl/create_env_files.erb.tmpl
+++ b/tmpl/create_env_files.erb.tmpl
@@ -4,7 +4,12 @@ mkdir -p /var/vcap/jobs/{{.Name}}/config/env
   # vim: ft=eruby
 
   def env_file_perms(fn)
-    "chown vcap:vcap #{fn}\nchmod 0600 #{fn}\n"
+    <<~EOS
+      if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+        chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} #{fn}
+      fi
+      chmod 0600 #{fn}
+    EOS
   end
 
   def env_file_content(v)

--- a/tmpl/create_env_files_spec.rb
+++ b/tmpl/create_env_files_spec.rb
@@ -28,7 +28,9 @@ describe "env_file_write" do
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0 <<"ENVGEN_EOF"
         bar
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0
 
 
@@ -37,14 +39,18 @@ describe "env_file_write" do
         quuux
         quuuux
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1
 
 
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2 <<"ENVGEN_EOF"
         {"grunt":"gorp"}
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2
       EOS
     }
@@ -65,7 +71,9 @@ describe "env_file_write" do
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo <<"ENVGEN_EOF"
         bar
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo
 
 
@@ -74,14 +82,18 @@ describe "env_file_write" do
         quuux
         quuuux
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz
 
 
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud <<"ENVGEN_EOF"
         {"grunt":"gorp"}
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud
       EOS
     }
@@ -96,7 +108,9 @@ describe "env_file_write" do
         hello there
         i am fine
         ENVGEN_EOF
-        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv
+        if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+          chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} /var/vcap/jobs/{{.Name}}/config/env/MyEnv
+        fi
         chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv
 
       EOS

--- a/tmpl/create_env_files_spec.rb
+++ b/tmpl/create_env_files_spec.rb
@@ -1,0 +1,92 @@
+#! /usr/bin/env ruby
+#
+#  unit tests for the helpers in `create_env_files.erb.tmpl`
+#
+
+#
+#  paste ruby code from `create_env_files.erb.tmpl` here and run `rspec path/to/this/file`
+#
+
+#
+#  below here are the unit tests
+#
+require "rspec"
+require "json"
+
+describe "env_file_write" do
+  context "Array" do
+    let(:value) {
+      [
+        "bar",
+        ["quux", "quuux", "quuuux"],
+        { "grunt" => "gorp" },
+      ]
+    }
+
+    let(:expected) {
+      <<~EOS
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0 <<"ENVGEN_EOF"
+        bar
+        ENVGEN_EOF
+
+
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1 <<"ENVGEN_EOF"
+        quux
+        quuux
+        quuuux
+        ENVGEN_EOF
+
+
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2 <<"ENVGEN_EOF"
+        {"grunt":"gorp"}
+        ENVGEN_EOF
+      EOS
+    }
+    it { expect(env_file_writer(value, "MyEnv")).to eq(expected) }
+  end
+
+  context "Hash" do
+    let(:value) {
+      {
+        "foo" => "bar",
+        "baz" => ["quux", "quuux", "quuuux"],
+        "thud" => { "grunt" => "gorp" },
+      }
+    }
+
+    let(:expected) {
+      <<~EOS
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo <<"ENVGEN_EOF"
+        bar
+        ENVGEN_EOF
+
+
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz <<"ENVGEN_EOF"
+        quux
+        quuux
+        quuuux
+        ENVGEN_EOF
+
+
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud <<"ENVGEN_EOF"
+        {"grunt":"gorp"}
+        ENVGEN_EOF
+      EOS
+    }
+    it { expect(env_file_writer(value, "MyEnv")).to eq(expected) }
+  end
+
+  context "String" do
+    let(:value) { "hello there\ni am fine" }
+    let(:expected) {
+      <<~EOS
+        cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv <<"ENVGEN_EOF"
+        hello there
+        i am fine
+        ENVGEN_EOF
+
+      EOS
+    }
+    it { expect(env_file_writer(value, "MyEnv")).to eq(expected) }
+  end
+end

--- a/tmpl/create_env_files_spec.rb
+++ b/tmpl/create_env_files_spec.rb
@@ -28,6 +28,8 @@ describe "env_file_write" do
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0 <<"ENVGEN_EOF"
         bar
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_0
 
 
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1 <<"ENVGEN_EOF"
@@ -35,11 +37,15 @@ describe "env_file_write" do
         quuux
         quuuux
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_1
 
 
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2 <<"ENVGEN_EOF"
         {"grunt":"gorp"}
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_2
       EOS
     }
     it { expect(env_file_writer(value, "MyEnv")).to eq(expected) }
@@ -59,6 +65,8 @@ describe "env_file_write" do
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo <<"ENVGEN_EOF"
         bar
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_foo
 
 
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz <<"ENVGEN_EOF"
@@ -66,11 +74,15 @@ describe "env_file_write" do
         quuux
         quuuux
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_baz
 
 
         cat > /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud <<"ENVGEN_EOF"
         {"grunt":"gorp"}
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv_thud
       EOS
     }
     it { expect(env_file_writer(value, "MyEnv")).to eq(expected) }
@@ -84,6 +96,8 @@ describe "env_file_write" do
         hello there
         i am fine
         ENVGEN_EOF
+        chown vcap:vcap /var/vcap/jobs/{{.Name}}/config/env/MyEnv
+        chmod 0600 /var/vcap/jobs/{{.Name}}/config/env/MyEnv
 
       EOS
     }


### PR DESCRIPTION
This addresses the issue described at #19

First commit erects some unit tests around the ruby helpers used by `envgen` so that I can make the second commit with confidence.

The second commit adds two lines after the creation of each env file:

* `chmod 0600 <filename>`
* `chown vcap:vcap <filename>`

so that the files look like:

```
$ ls -lt /var/vcap/data/jobs/web/*/config/env
total 24
-rw------- 1 vcap vcap 1675 Mar  9 17:31 CONCOURSE_TSA_HOST_KEY
-rw------- 1 vcap vcap 1675 Mar  9 17:31 CONCOURSE_SESSION_SIGNING_KEY
-rw------- 1 vcap vcap  381 Mar  9 17:31 CONCOURSE_TSA_AUTHORIZED_KEYS_0
-rw------- 1 vcap vcap 1679 Mar  9 17:31 CONCOURSE_POSTGRES_CLIENT_KEY
-rw------- 1 vcap vcap 1188 Mar  9 17:31 CONCOURSE_POSTGRES_CLIENT_CERT
-rw------- 1 vcap vcap 1147 Mar  9 17:31 CONCOURSE_POSTGRES_CA_CERT
```

@vito raised the point that the `worker` job runs as root, so maybe we need to do something more complicated here. Happy to discuss!
