### PR TITLE
register concourse worker as a systemd service

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -11,7 +11,10 @@ templates:
   ctl.erb: bin/ctl
   drain.erb: bin/drain
   pre_start.erb: bin/pre_start
+  concourse_start.erb: bin/concourse_start
+  concourse_stop.erb: bin/concourse_stop
   env.sh.erb: config/env.sh
+  concourse.service: config/concourse.service
   worker_gateway_host_key.pub.erb: config/worker_gateway_host_key.pub
 
 packages:

--- a/jobs/worker/templates/concourse.service
+++ b/jobs/worker/templates/concourse.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Concourse worker runtime
+
+[Service]
+Type=exec
+ExecStart=/var/vcap/jobs/worker/bin/concourse_start
+ExecStop=/var/vcap/jobs/worker/bin/concourse_stop
+Delegate=yes
+KillMode=none

--- a/jobs/worker/templates/concourse_start.erb
+++ b/jobs/worker/templates/concourse_start.erb
@@ -1,0 +1,37 @@
+#!/bin/bash
+# vim: ft=sh
+
+set -e -u
+
+RUN_DIR=/var/vcap/sys/run/worker
+mkdir -p $RUN_DIR
+PIDFILE=${RUN_DIR}/worker.pid
+
+LOG_DIR=/var/vcap/sys/log/worker
+mkdir -p $LOG_DIR
+exec 1>> $LOG_DIR/worker.stdout.log
+exec 2>> $LOG_DIR/worker.stderr.log
+
+/var/vcap/jobs/worker/bin/pre_start
+
+source /var/vcap/jobs/worker/config/env.sh
+
+set -x
+
+function increase_max_open_fds() {
+  ulimit -n 65536
+}
+
+function increase_max_procs() {
+  echo 4194304 > /proc/sys/kernel/pid_max
+  ulimit -u unlimited
+}
+
+increase_max_open_fds
+increase_max_procs
+
+start-stop-daemon \
+  --pidfile $PIDFILE \
+  --make-pidfile \
+  --start \
+  --exec /var/vcap/packages/concourse/bin/concourse worker

--- a/jobs/worker/templates/concourse_stop.erb
+++ b/jobs/worker/templates/concourse_stop.erb
@@ -1,0 +1,17 @@
+#!/bin/bash
+# vim: ft=sh
+
+set -e -u
+
+RUN_DIR=/var/vcap/sys/run/worker
+PIDFILE=${RUN_DIR}/worker.pid
+
+set -x
+
+start-stop-daemon \
+    --pidfile $PIDFILE \
+    --remove-pidfile \
+    --stop \
+    --oknodo \
+    --retry=TERM/15/QUIT/2/KILL
+

--- a/jobs/worker/templates/ctl.erb
+++ b/jobs/worker/templates/ctl.erb
@@ -3,55 +3,47 @@
 
 set -e -u
 
-RUN_DIR=/var/vcap/sys/run/worker
-mkdir -p $RUN_DIR
-PIDFILE=${RUN_DIR}/worker.pid
-
 LOG_DIR=/var/vcap/sys/log/worker
 mkdir -p $LOG_DIR
-exec 1>> $LOG_DIR/worker.stdout.log
-exec 2>> $LOG_DIR/worker.stderr.log
-
-/var/vcap/jobs/worker/bin/pre_start
+exec 1>> "${LOG_DIR}/ctl.stdout.log"
+exec 2>> "${LOG_DIR}/ctl.stderr.log"
 
 source /var/vcap/jobs/worker/config/env.sh
 
+IS_RUNNING_SYSTEMD=false
+if [ -d "/run/systemd/system" ]; then
+  IS_RUNNING_SYSTEMD=true
+fi
+
 set -x
 
-function increase_max_open_fds() {
-  ulimit -n 65536
+install_systemd_service() {
+  if [ -n "${IS_RUNNING_SYSTEMD}" ]; then
+    rm -f /lib/systemd/system/concourse.service
+    cp /var/vcap/jobs/worker/config/concourse.service /lib/systemd/system/
+    /bin/systemctl daemon-reload
+  fi
 }
 
-function increase_max_procs() {
-  echo 4194304 > /proc/sys/kernel/pid_max
-  ulimit -u unlimited
+
+worker() {
+  if [ -n "${IS_RUNNING_SYSTEMD}" ]; then
+    /bin/systemctl "${1}" concourse.service
+  else
+    /var/vcap/jobs/worker/bin/concourse_"${1}"
+  fi
 }
+
 
 case $1 in
   start)
-    increase_max_open_fds
-    increase_max_procs
-
-    start-stop-daemon \
-      --pidfile $PIDFILE \
-      --make-pidfile \
-      --start \
-      --exec /var/vcap/packages/concourse/bin/concourse worker
-
-    ;;
-
+    install_systemd_service
+    worker "start"
+  ;;
   stop)
-    start-stop-daemon \
-      --pidfile $PIDFILE \
-      --remove-pidfile \
-      --stop \
-      --oknodo \
-      --retry=TERM/15/QUIT/2/KILL
-
-    ;;
-
+    worker "stop"
+  ;;
   *)
     echo "Usage: $0 {start|stop}"
-
-    ;;
+  ;;
 esac


### PR DESCRIPTION
concourse/concourse#3613

Garden manages the cgroups for the containers it spawns, systemd thinks it's the only manager of cgroups and will move cgroups around as it deems fit. 

Solution is to let systemd know that Concourse (which is the parent of garden) will be managing it's own cgroups by installing a service with `Delegate=yes`