### PR TITLE
Expose external-garden-address via garden.external_address

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -189,6 +189,11 @@ properties:
       Allow containers to reach the worker VM's network.
     default: false
 
+  garden.external_address:
+    env: CONCOURSE_EXTERNAL_GARDEN_ADDRESS
+    description: |
+      Garden server connection address, when specified will not use embedded garden
+
   debug.bind_ip:
     env: CONCOURSE_DEBUG_BIND_IP
     description: |

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -98,6 +98,10 @@ export CONCOURSE_EPHEMERAL=<%= esc(env_flag(v)) %>
 export CONCOURSE_GARDEN_ALLOW_HOST_ACCESS=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("garden.external_address") do |v| -%>
+export CONCOURSE_EXTERNAL_GARDEN_ADDRESS=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("garden.deny_networks") do |v| -%>
 export CONCOURSE_GARDEN_DENY_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>
@@ -169,4 +173,3 @@ export CONCOURSE_REBALANCE_INTERVAL=<%= esc(env_flag(v)) %>
 <% if_p("worker_gateway.worker_key.private_key") do |v| -%>
 export CONCOURSE_TSA_WORKER_PRIVATE_KEY=<%= esc(env_file_flag(v, "CONCOURSE_TSA_WORKER_PRIVATE_KEY")) %>
 <% end -%>
-


### PR DESCRIPTION
Addresses: https://github.com/concourse/concourse-bosh-release/issues/17
Depends on: https://github.com/concourse/concourse/pull/3806