### PR TITLE
Use bosh links for getting db info for bbr

### DIFF
--- a/jobs/bbr-atcdb/spec
+++ b/jobs/bbr-atcdb/spec
@@ -15,7 +15,10 @@ consumes:
 - name: postgres
   type: database
   optional: true
-  
+- name: concourse_db
+  type: concourse_db
+  optional: true
+
 properties:
   postgresql_database:
     description: |

--- a/jobs/bbr-atcdb/spec
+++ b/jobs/bbr-atcdb/spec
@@ -57,3 +57,24 @@ properties:
     description: |
       Password to use when connecting.
 
+  postgresql.tls.enabled:
+    description: |
+      Whether or not to use TLS when connecting to the database.
+    default: false
+
+  postgresql.tls.skip_host_verify:
+    description: |
+      Skip host verification for Server CA certificate. Needs to be set to `true` on GCP.
+    default: false
+
+  postgresql.tls.cert.ca:
+    description: |
+      Server CA certificate. This must be included if any of the tls block is specified.
+
+  postgresql.tls.cert.certificate:
+    description: |
+      Client certificate for Mutual TLS. This must be specified if `private_key` is given.
+
+  postgresql.tls.cert.private_key:
+    description: |
+      Client private key for Mutual TLS. This must be specified if `certificate` is given.

--- a/jobs/bbr-atcdb/templates/config.json.erb
+++ b/jobs/bbr-atcdb/templates/config.json.erb
@@ -35,8 +35,16 @@
       postgres_host = l.instances.first.address
     end if postgres_host.empty?
 
+    if_link("concourse_db") do |cdb|
+      postgres_host = cdb.p("postgressql.host", "")
+      postgres_port = cdb.p("postgressql.port")
+      postgres_role_name = cdb.p("postgressql.role.name")
+      postgres_role_password = cdb.p("postgressql.role.password")
+      postgres_database = cdb.p("postgressql.database")
+    end if postgres_host.empty?
+
     if postgres_host.empty?
-      raise "postgres.host not set and no 'db' or 'postgres' link available"
+      raise "postgres.host not set and no 'db', 'postgres' or 'concourse_db' link available"
     end
 
     JSON.pretty_generate(

--- a/jobs/bbr-atcdb/templates/config.json.erb
+++ b/jobs/bbr-atcdb/templates/config.json.erb
@@ -6,6 +6,11 @@
     postgres_role_name = ""
     postgres_role_password = ""
     postgres_database = ""
+    postgres_tls_enabled = false
+    postgres_tls_skip_host_verify = false
+    postgres_tls_ca = ""
+    postgres_tls_public_cert = ""
+    postgres_tls_private_key = ""
 
     if_p("postgresql.address") do |addr|
       postgres_host, postgres_port = addr.split(":")
@@ -16,6 +21,13 @@
     postgres_database = p("postgresql.database")
     postgres_role_name = p("postgresql.role.name")
     postgres_role_password = p("postgresql.role.password", "")
+    postgres_tls_enabled = p("postgresql.tls.enabled", false)
+    if postgres_tls_enabled
+      postgres_tls_skip_host_verify = p("postgresql.tls.skip_host_verify", false)
+      postgres_tls_ca = p("postgresql.tls.cert.ca")
+      postgres_tls_public_cert = p("postgresql.tls.cert.certificate")
+      postgres_tls_private_key = p("postgresql.tls.cert.private_key")
+    end
 
     if_link("db") do |db|
       postgres_host = db.instances.first.address
@@ -43,16 +55,34 @@
       postgres_database = cdb.p("postgressql.database")
     end if postgres_host.empty?
 
+    if_link("concourse_db") do |cdb|
+      postgres_tls_enabled = cdb.p("postgresql.sslmode", false)
+      if postgres_tls_enabled
+        postgres_tls_ca = cdb.p("postgresql.ca_cert")
+        postgres_tls_public_cert = cdb.p("postgresql.client_cert.certificate")
+        postgres_tls_private_key = cdb.p("postgresql.client_cert.private_key")
+      end
+    end
+
     if postgres_host.empty?
       raise "postgres.host not set and no 'db', 'postgres' or 'concourse_db' link available"
     end
 
-    JSON.pretty_generate(
+    config_data = {
       'username' => postgres_role_name,
       'password' => postgres_role_password,
       'host' => postgres_host,
       'port' => postgres_port,
       'database' => postgres_database,
       'adapter' => 'postgres'
-    )
+    }
+
+    if postgres_tls_enabled
+      config_data['tls.skip_host_verify'] = postgres_tls_skip_host_verify
+      config_data['tls.cert.ca'] = postgres_tls_ca
+      config_data['tls.cert.certificate'] = postgres_tls_public_cert
+      config_data['tls.cert.private_key'] = postgres_tls_private_key
+    end
+
+    JSON.pretty_generate(config_data)
 %>

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -27,6 +27,20 @@ provides:
   - tls.bind_port
   - worker_gateway.bind_port
   - worker_gateway.host_key
+- name: concourse_db
+  type: concoruse_db
+  properties:
+  - postgresql.host
+  - postgresql.port
+  - postgresql.socket
+  - postgresql.database
+  - postgresql.role.name
+  - postgresql.role.password
+  - postgresql.sslmode
+  - postgresql.ca_cert
+  - postgresql.client_cert
+  - postgresql.connect_timeout
+
 
 properties:
   bind_ip:

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -28,18 +28,16 @@ provides:
   - worker_gateway.bind_port
   - worker_gateway.host_key
 - name: concourse_db
-  type: concoruse_db
+  type: concourse_db
   properties:
   - postgresql.host
   - postgresql.port
-  - postgresql.socket
   - postgresql.database
   - postgresql.role.name
   - postgresql.role.password
   - postgresql.sslmode
   - postgresql.ca_cert
   - postgresql.client_cert
-  - postgresql.connect_timeout
 
 
 properties:


### PR DESCRIPTION
- The web job provide it's db connection info as bosh links
- The bbr-atcdb job consumes from the web job if available

Thoughts?

For https://github.com/concourse/concourse/issues/2332