### PR TITLE
Fix logic for running worker without systemd

### DIFF
--- a/jobs/worker/templates/ctl.erb
+++ b/jobs/worker/templates/ctl.erb
@@ -18,7 +18,7 @@ fi
 set -x
 
 install_systemd_service() {
-  if [ -n "${IS_RUNNING_SYSTEMD}" ]; then
+  if [ "${IS_RUNNING_SYSTEMD}" != "false" ]; then
     rm -f /lib/systemd/system/concourse.service
     cp /var/vcap/jobs/worker/config/concourse.service /lib/systemd/system/
     /bin/systemctl daemon-reload
@@ -27,7 +27,7 @@ install_systemd_service() {
 
 
 worker() {
-  if [ -n "${IS_RUNNING_SYSTEMD}" ]; then
+  if [ "${IS_RUNNING_SYSTEMD}" != "false" ]; then
     /bin/systemctl "${1}" concourse.service
   else
     /var/vcap/jobs/worker/bin/concourse_"${1}"


### PR DESCRIPTION
In worker/bin/ctl.erb a check for systemd sets IS_RUNNING_SYSTEMD=true. Prior to that IS_RUNNING_SYSTEMD is initialized to 'false'. In the conditional to check the state `[ -n "${IS_RUNNING_SYSTEMD}" ]` is used, which fails due to the prior initialization.


This is required to deploy concourse via docker-cpi. Which is very useful way to run it locally.