### PR TITLE
Improve use of BOSH links in bbr-atcdb config template

### DIFF
--- a/dev/vbox/topgun
+++ b/dev/vbox/topgun
@@ -5,6 +5,11 @@ set -e -u
 cd $(dirname $0)/../..
 source ./dev/common.bash
 
+export BOSH_ENVIRONMENT="192.168.50.6"
+export BOSH_CLIENT="admin"
+export BOSH_CLIENT_SECRET="$(bosh int ./dev/vbox/creds.yml --path /admin_password)"
+export BOSH_CA_CERT="$(bosh int ./dev/vbox/creds.yml --path /director_ssl/ca)"
+
 by "force-creating dev release..."
 bosh create-release --force
 
@@ -12,6 +17,5 @@ by "uploading release..."
 bosh -e vbox upload-release
 
 by "running topgun..."
-cd ./src/github.com/concourse/topgun
-BOSH_ENVIRONMENT=vbox \
-  ginkgo -r -p -nodes=3 "$@"
+cd ../concourse/topgun
+ginkgo -p "$@"

--- a/jobs/bbr-atcdb/spec
+++ b/jobs/bbr-atcdb/spec
@@ -1,3 +1,4 @@
+# vim: ft=yaml
 ---
 name: bbr-atcdb
 
@@ -9,9 +10,6 @@ templates:
 packages: []
 
 consumes:
-- name: db
-  type: postgresql
-  optional: true
 - name: postgres
   type: database
   optional: true
@@ -20,10 +18,6 @@ consumes:
   optional: true
 
 properties:
-  postgresql_database:
-    description: |
-      Name of the database to use from the `postgresql` link.
-
   postgresql.host:
     description: |
       IP address or DNS name of a PostgreSQL server to connect to.

--- a/jobs/bbr-atcdb/templates/config.json.erb
+++ b/jobs/bbr-atcdb/templates/config.json.erb
@@ -1,27 +1,17 @@
 <%=
     require 'json'
 
-    postgres_host = ""
-    postgres_port = ""
-    postgres_role_name = ""
-    postgres_role_password = ""
-    postgres_database = ""
-    postgres_tls_enabled = false
-    postgres_tls_skip_host_verify = false
-    postgres_tls_ca = ""
-    postgres_tls_public_cert = ""
-    postgres_tls_private_key = ""
-
-    if_p("postgresql.address") do |addr|
-      postgres_host, postgres_port = addr.split(":")
-    end
-
     postgres_host = p("postgresql.host", "")
     postgres_port = p("postgresql.port")
     postgres_database = p("postgresql.database")
     postgres_role_name = p("postgresql.role.name")
     postgres_role_password = p("postgresql.role.password", "")
     postgres_tls_enabled = p("postgresql.tls.enabled", false)
+    postgres_tls_skip_host_verify = false
+    postgres_tls_ca = ""
+    postgres_tls_public_cert = ""
+    postgres_tls_private_key = ""
+
     if postgres_tls_enabled
       postgres_tls_skip_host_verify = p("postgresql.tls.skip_host_verify", false)
       postgres_tls_ca = p("postgresql.tls.cert.ca")
@@ -29,43 +19,53 @@
       postgres_tls_private_key = p("postgresql.tls.cert.private_key")
     end
 
-    if_link("db") do |db|
-      postgres_host = db.instances.first.address
-      postgres_port = db.p("bind_port")
-      postgres_database = p("postgresql_database")
-
-      postgres_db = db.p("databases").find { |db| db["name"] == postgres_database }
-      if postgres_db.nil?
-        raise "database '#{db_name}' not provided by 'postgresql' link"
+    if postgres_host.empty?
+      if_link("concourse_db") do |cdb|
+        postgres_host = cdb.p("postgresql.host", "")
       end
 
-      postgres_role_name = postgres_db["role"]
-      postgres_role_password = postgres_db["password"]
-    end if postgres_host.empty?
+      if postgres_host.empty?
+        if_link("postgres") do |p|
+          postgres_host = p.instances.first.address
+        end
+      end
 
-    if_link("postgres") do |l|
-      postgres_host = l.instances.first.address
-    end if postgres_host.empty?
-
-    if_link("concourse_db") do |cdb|
-      postgres_host = cdb.p("postgressql.host", "")
-      postgres_port = cdb.p("postgressql.port")
-      postgres_role_name = cdb.p("postgressql.role.name")
-      postgres_role_password = cdb.p("postgressql.role.password")
-      postgres_database = cdb.p("postgressql.database")
-    end if postgres_host.empty?
-
-    if_link("concourse_db") do |cdb|
-      postgres_tls_enabled = cdb.p("postgresql.sslmode", false)
-      if postgres_tls_enabled
-        postgres_tls_ca = cdb.p("postgresql.ca_cert")
-        postgres_tls_public_cert = cdb.p("postgresql.client_cert.certificate")
-        postgres_tls_private_key = cdb.p("postgresql.client_cert.private_key")
+      if postgres_host.empty?
+        raise "postgres.host not found through either properties or links"
       end
     end
 
-    if postgres_host.empty?
-      raise "postgres.host not set and no 'db', 'postgres' or 'concourse_db' link available"
+    if_link("concourse_db") do |cdb|
+      if postgres_database.empty?
+        postgres_database = cdb.p("postgresql.database")
+      end
+
+      if not postgres_port.zero?
+        postgres_port = cdb.p("postgresql.port")
+      end
+
+      if postgres_role_name.empty?
+        postgres_role_name = cdb.p("postgresql.role.name")
+      end
+
+      if postgres_role_password.empty?
+        postgres_role_password = cdb.p("postgresql.role.password")
+      end
+
+      postgres_tls_enabled = cdb.p("postgresql.sslmode", postgres_tls_enabled)
+      if postgres_tls_enabled
+        if postgres_tls_ca.empty?
+          postgres_tls_ca = cdb.p("postgresql.ca_cert")
+        end
+
+        if postgres_tls_public_cert.empty?
+          postgres_tls_public_cert = cdb.p("postgresql.client_cert.certificate")
+        end
+
+        if postgres_tls_private_key.empty?
+          postgres_tls_private_key = cdb.p("postgresql.client_cert.private_key")
+        end
+      end
     end
 
     config_data = {


### PR DESCRIPTION
Previously, `bbr-atcdb` was trying to find properties that don't exist ("postgre**ss**ql")

https://github.com/concourse/concourse-bosh-release/blob/b8dc05d9c558939debbc5e83ee730abbc01e1f4d/jobs/bbr-atcdb/templates/config.json.erb#L50-L56

in the job that exposes them https://github.com/concourse/concourse-bosh-release/blob/b8dc05d9c558939debbc5e83ee730abbc01e1f4d/jobs/web/spec#L30-L40

This meant that the properties would never be found.

fixes #34 

 Next steps:

- [x] check if there are enough `topgun` tests that cover this use of the links in place for `concourse_db`.