### PR TITLE
According to docs it should be fewest-build-containers

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -734,7 +734,7 @@ properties:
     description: |
       Method by which a worker is selected during container placement.
 
-      Options are "volume-locality", "random", and "least-build-containers".
+      Options are "volume-locality", "random", and "fewest-build-containers".
     default: "volume-locality"
 
   baggageclaim_response_header_timeout:


### PR DESCRIPTION
https://concourse-ci.org/container-placement.html and https://github.com/concourse/concourse/blob/master/atc/atccmd/command.go give that option as fewest-build-containers not least-build-containers