### PR TITLE
Update spec

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -76,7 +76,6 @@ properties:
       Maximum wait time in Go duration format (1m = 1 minute) for worker drain
       to be finished. Only applies when worker is getting shutdown.
 
-      If not specified, it will be indefinite.
     default: 1h
 
   ephemeral:


### PR DESCRIPTION
drain_timeout defaults to 1h, the description was misleading indicating that it is indefinite by default.