### PR TITLE
make the garden.max_containers property configurable

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,11 +2,11 @@ btrfs/btrfs-tools-4.4.tar.gz:
   size: 3062268
   object_id: 9c8e0f55-d9e0-4a6a-51f3-1b175f3b2551
   sha: 94279d010ebd4829396af9212f9c1e73e75d914e
-concourse/concourse-5.3.0-rc.12-linux-amd64.tgz:
-  size: 1005146492
-  object_id: baa2ad84-5aff-4b6e-69f3-47c7546a082b
-  sha: 285f9f140735752bf4cd6902afdc15fa28d94b1f
-concourse/concourse-5.3.0-rc.12-windows-amd64.zip:
-  size: 61070587
-  object_id: 8a5f87ac-4353-403a-557d-a8c0dd742857
-  sha: 3102ab30d6a4ba9e470adc76b06427214628762a
+concourse/concourse-5.3.0-rc.13-linux-amd64.tgz:
+  size: 1005141904
+  object_id: 38adaa7a-2b68-4b16-6041-5ebf4df09b67
+  sha: 29c554b47dfdbbc53abcca27272899a30bb5bd4f
+concourse/concourse-5.3.0-rc.13-windows-amd64.zip:
+  size: 61069609
+  object_id: 07675ce8-dc41-49a7-5f4b-0939648a76a3
+  sha: 759e3a1fa7865128642fccf833ecd814a0ad6213

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -197,6 +197,12 @@ properties:
       Allow containers to reach the worker VM's network.
     default: false
 
+  garden.max_containers:
+    env: CONCOURSE_GARDEN_MAX_CONTAINERS
+    description: |
+      Maximum container capacity to advertise.
+    default: 250
+
   debug.bind_ip:
     env: CONCOURSE_DEBUG_BIND_IP
     description: |

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -102,6 +102,10 @@ export CONCOURSE_EXTERNAL_GARDEN_URL=<%= esc(env_flag(v)) %>
 export CONCOURSE_GARDEN_ALLOW_HOST_ACCESS=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("garden.max_containers") do |v| -%>
+export CONCOURSE_GARDEN_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("garden.deny_networks") do |v| -%>
 export CONCOURSE_GARDEN_DENY_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>


### PR DESCRIPTION
This will allow teams to more fully take advantage of underutilized workers. Often teams provision more workers than they actually need in order to create more room for containers. Instead they could just bump the max_containers and not have to get another worker. 

Josh and @aemengo

Co-authored-by: Anthony Emengo <aemengo@pivotal.io>