### PR TITLE
Fix example for add_local_users in jobs/web/spec

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -236,9 +236,9 @@ properties:
       password can be bcrypted. Bcrypted password must have a strength of 10 or
       higher or the user will not be able to login.
     example:
-      some-user: $2a$10$sKZelZprWWcBAWbp28rB1uFef0Ybxsiqh05uo.H8EIm0sWc6IZGJu
-      some-other-user: $2a$10$.YIYH.5EWQcCvfE49xH/.OhIhGFiNtn.tQq.4pznpcrqZvoLxuKeC
-      some-plaintext-user: a-plaintext-password
+      some-user:$2a$10$sKZelZprWWcBAWbp28rB1uFef0Ybxsiqh05uo.H8EIm0sWc6IZGJu
+      some-other-user:$2a$10$.YIYH.5EWQcCvfE49xH/.OhIhGFiNtn.tQq.4pznpcrqZvoLxuKeC
+      some-plaintext-user:a-plaintext-password
 
   github_auth.client_id:
     env: CONCOURSE_GITHUB_CLIENT_ID


### PR DESCRIPTION
There must not be a space after the colon, otherwise this will be interpreted as yaml/json and not properly passed on.