### PR TITLE
Make Garden network pool configurable

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -197,6 +197,13 @@ properties:
       Allow containers to reach the worker VM's network.
     default: false
 
+  garden.network_pool:
+    env: CONCOURSE_GARDEN_NETWORK_POOL
+    description: |
+      Allow to configure the network pool. Make sure your container
+      network pool does not overlap with any other addresses in your network.
+    default: 10.254.0.0/22
+
   debug.bind_ip:
     env: CONCOURSE_DEBUG_BIND_IP
     description: |

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -114,6 +114,10 @@ export CONCOURSE_GARDEN_DNS_SERVER=<%= esc(env_flag(v)) %>
 export CONCOURSE_GARDEN_USE_HOUDINI=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("garden.network_pool") do |v| -%>
+export CONCOURSE_GARDEN_NETWORK_POOL=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("healthcheck.bind_ip") do |v| -%>
 export CONCOURSE_HEALTHCHECK_BIND_IP=<%= esc(env_flag(v)) %>
 <% end -%>


### PR DESCRIPTION
* allow to configure env variable CONCOURSE_GARDEN_NETWORK_POOL
* required if you want to use Concourse, inside the default network pool
  range 10.254.0.0/22