### PR TITLE
add main team flags for cf auth space roles

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -606,14 +606,42 @@ properties:
   main_team.auth.cf.spaces:
     env: CONCOURSE_MAIN_TEAM_CF_SPACE
     description: |
-      List of CloudFoundry Spaces that are authorized for the main team
+      (Deprecated) List of CloudFoundry Spaces whose 'developer' users are authorized for the main team
+    example:
+    - myorg:myspace
+
+  main_team.auth.cf.spaces_with_any_role:
+    env: CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_ANY_ROLE
+    description: |
+      List of CloudFoundry Spaces whose users with any role are authorized for the main team
+    example:
+    - myorg:myspace
+
+  main_team.auth.cf.spaces_with_developer_role:
+    env: CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_DEVELOPER_ROLE
+    description: |
+      List of CloudFoundry Spaces whose 'developer' users are authorized for the main team
+    example:
+    - myorg:myspace
+
+  main_team.auth.cf.spaces_with_auditor_role:
+    env: CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_AUDITOR_ROLE
+    description: |
+      List of CloudFoundry Spaces whose 'auditor' users are authorized for the main team
+    example:
+    - myorg:myspace
+
+  main_team.auth.cf.spaces_with_manager_role:
+    env: CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_MANAGER_ROLE
+    description: |
+      List of CloudFoundry Spaces whose 'manager' users are authorized for the main team
     example:
     - myorg:myspace
 
   main_team.auth.cf.space_guids:
     env: CONCOURSE_MAIN_TEAM_CF_SPACE_GUID
     description: |
-      List of CloudFoundry Space GUIDs that are authorized for the main team
+      (Deprecated) List of CloudFoundry Space GUIDs that are authorized for the main team
 
   main_team.auth.ldap.users:
     env: CONCOURSE_MAIN_TEAM_LDAP_USER

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -655,6 +655,22 @@ processes:
     CONCOURSE_MAIN_TEAM_CF_SPACE: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("main_team.auth.cf.spaces_with_any_role") do |v| -%>
+    CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_ANY_ROLE: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("main_team.auth.cf.spaces_with_auditor_role") do |v| -%>
+    CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_AUDITOR_ROLE: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("main_team.auth.cf.spaces_with_developer_role") do |v| -%>
+    CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_DEVELOPER_ROLE: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("main_team.auth.cf.spaces_with_manager_role") do |v| -%>
+    CONCOURSE_MAIN_TEAM_CF_SPACE_WITH_MANAGER_ROLE: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("main_team.auth.cf.users") do |v| -%>
     CONCOURSE_MAIN_TEAM_CF_USER: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
Adding
```
CONCOURSE_MAIN_TEAM_CF_SPACE_DEVELOPER
CONCOURSE_MAIN_TEAM_CF_SPACE_AUDITOR
CONCOURSE_MAIN_TEAM_CF_SPACE_MANAGER
```
to spec