### PR TITLE
Update README with how to use scripts/generate-job-templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ documentation](https://bosh.io/docs/) first.
 If you're just looking to get Concourse running quickly and kick the tires, you
 may want to try the [Quick Start](https://concourse-ci.org/install.html)
 instead.
+
+## Developing
+
+If you are adding new Concourse flags to one of the job specs you must run `scripts/generate-job-templates` to add the new flags to the job templates.


### PR DESCRIPTION
Currently this is knowledge stored in a few individual heads. Now it's
stored where others may see it or at least sumble across it when working
with the bosh release.

[This comment] is what prompted me to make this addition.

[This comment]:https://github.com/concourse/concourse-bosh-release/pull/63#pullrequestreview-311948056