### PR TITLE
Add CONCOURSE_GARDEN_REQUEST_TIMEOUT config

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -795,6 +795,7 @@ properties:
     description: |
       How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
       0 means no timeout.
+    example: 5m
 
   postgresql.host:
     env: CONCOURSE_POSTGRES_HOST

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -790,6 +790,12 @@ properties:
       format (1m = 1 minute).
     default: 1m
 
+  garden_request_timeout:
+    env: CONCOURSE_GARDEN_REQUEST_TIMEOUT
+    description: |
+      How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
+      0 means no timeout.
+
   postgresql.host:
     env: CONCOURSE_POSTGRES_HOST
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -351,6 +351,10 @@ processes:
     CONCOURSE_EXTERNAL_URL: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("garden_request_timeout") do |v| -%>
+    CONCOURSE_GARDEN_REQUEST_TIMEOUT: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("gc.check_recycle_period") do |v| -%>
     CONCOURSE_GC_CHECK_RECYCLE_PERIOD: <%= env_flag(v).to_json %>
 <% end -%>

--- a/jobs/worker-windows/spec
+++ b/jobs/worker-windows/spec
@@ -77,6 +77,7 @@ properties:
     description: |
       How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
       0 means no timeout.
+    example: 5m
 
   sweep_interval:
     env: CONCOURSE_SWEEP_INTERVAL

--- a/jobs/worker-windows/spec
+++ b/jobs/worker-windows/spec
@@ -72,6 +72,12 @@ properties:
       If set, the worker will immediately disappear upon stalling.
     default: false
 
+  garden.request_timeout:
+    env: CONCOURSE_GARDEN_REQUEST_TIMEOUT
+    description: |
+      How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
+      0 means no timeout.
+
   sweep_interval:
     env: CONCOURSE_SWEEP_INTERVAL
     description: |

--- a/jobs/worker-windows/templates/env.ps1.erb
+++ b/jobs/worker-windows/templates/env.ps1.erb
@@ -87,6 +87,10 @@ $env:CONCOURSE_BAGGAGECLAIM_DRIVER = <%= esc(env_flag(v)) %>
 $env:CONCOURSE_EPHEMERAL = <%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("garden.request_timeout") do |v| -%>
+$env:CONCOURSE_GARDEN_REQUEST_TIMEOUT = <%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("http_proxy_url") do |v| -%>
 $env:http_proxy = <%= esc(env_flag(v)) %>
 <% end -%>

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -178,6 +178,12 @@ properties:
 
       If specified, the other garden.* properties have no effect.
 
+  garden.request_timeout:
+    env: CONCOURSE_GARDEN_REQUEST_TIMEOUT
+    description: |
+      How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
+      0 means no timeout.
+
   garden.deny_networks:
     env: CONCOURSE_GARDEN_DENY_NETWORK
     description: |

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -183,6 +183,7 @@ properties:
     description: |
       How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
       0 means no timeout.
+    example: 5m
 
   garden.deny_networks:
     env: CONCOURSE_GARDEN_DENY_NETWORK

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -102,10 +102,6 @@ export CONCOURSE_EXTERNAL_GARDEN_URL=<%= esc(env_flag(v)) %>
 export CONCOURSE_GARDEN_ALLOW_HOST_ACCESS=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("garden.max_containers") do |v| -%>
-export CONCOURSE_GARDEN_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
-<% end -%>
-
 <% if_p("garden.deny_networks") do |v| -%>
 export CONCOURSE_GARDEN_DENY_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>
@@ -114,8 +110,16 @@ export CONCOURSE_GARDEN_DENY_NETWORK=<%= esc(env_flag(v)) %>
 export CONCOURSE_GARDEN_DNS_SERVER=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("garden.max_containers") do |v| -%>
+export CONCOURSE_GARDEN_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("garden.network_pool") do |v| -%>
 export CONCOURSE_GARDEN_NETWORK_POOL=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("garden.request_timeout") do |v| -%>
+export CONCOURSE_GARDEN_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("garden.use_houdini") do |v| -%>


### PR DESCRIPTION
In [concourse/concourse#4707](https://github.com/concourse/concourse/pull/4707) we made the timeout applied to requests originating from either `atc` or `worker` configurable via the `--garden-request-timeout` flags (on both `worker` and `web`).

This PR adds configuration for such flag for the BOSH release.