### PR TITLE
Rename NewRelic compression flag

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -975,7 +975,7 @@ properties:
       Length of time to wait between emitting until all currently batched events are emitted.
     example: 60s
   newrelic.disable_compression:
-    env: CONCOURSE_NEWRELIC_DISABLE_COMPRESSION
+    env: CONCOURSE_NEWRELIC_BATCH_DISABLE_COMPRESSION
     description: |
       Disables compression of the batch before sending it.
     example: false

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -740,7 +740,7 @@ processes:
 <% end -%>
 
 <% if_p("newrelic.disable_compression") do |v| -%>
-    CONCOURSE_NEWRELIC_DISABLE_COMPRESSION: <%= env_flag(v).to_json %>
+    CONCOURSE_NEWRELIC_BATCH_DISABLE_COMPRESSION: <%= env_flag(v).to_json %>
 <% end -%>
 
 <% if_p("newrelic.service_prefix") do |v| -%>


### PR DESCRIPTION
Got the naming wrong for the compression flag in https://github.com/concourse/concourse-bosh-release/pull/64

CI found the error: https://ci.concourse-ci.org/teams/main/pipelines/release-5.5.x/jobs/bosh-check-props/builds/66