### PR TITLE
add vault namespace param

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1098,6 +1098,10 @@ properties:
     env: CONCOURSE_VAULT_SHARED_PATH
     description: |
       Path under which to lookup shared credentials.
+  vault.namespace:
+    env: CONCOURSE_VAULT_NAMESPACE
+    description: |
+      Vault namespace to use for authentication and secret lookup.
   vault.tls.ca_cert:
     type: certificate
     env_fields: {certificate: {env_file: CONCOURSE_VAULT_CA_CERT}}

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -935,6 +935,10 @@ processes:
     CONCOURSE_VAULT_AUTH_PARAM: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("vault.namespace") do |v| -%>
+    CONCOURSE_VAULT_NAMESPACE: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("vault.path_prefix") do |v| -%>
     CONCOURSE_VAULT_PATH_PREFIX: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
To address failures like https://nci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-check-props/builds/41.