### PR TITLE
jobs/web: Add Vault lookup templates flag

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1154,6 +1154,10 @@ properties:
     description: |
       Path under which to look up shared team/pipeline credentials.
     default: /concourse
+  vault.lookup_templates:
+    env: CONCOURSE_VAULT_LOOKUP_TEMPLATES
+    description: |
+      Path templates for credential lookup.
   vault.shared_path:
     env: CONCOURSE_VAULT_SHARED_PATH
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -1015,6 +1015,10 @@ processes:
     CONCOURSE_VAULT_AUTH_PARAM: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("vault.lookup_templates") do |v| -%>
+    CONCOURSE_VAULT_LOOKUP_TEMPLATES: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("vault.namespace") do |v| -%>
     CONCOURSE_VAULT_NAMESPACE: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
See https://github.com/concourse/concourse/pull/5013, further documentation in https://github.com/concourse/docs/pull/292.

This allows more detailed customization of how the Vault credential manager looks for team- and pipeline-dependent secrets.

Signed-off-by: Alexander Gurney <alexander_gurney@cable.comcast.com>