### PR TITLE
Use Let's Encrypt ACME API v2

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1381,7 +1381,7 @@ properties:
     env: CONCOURSE_LETS_ENCRYPT_ACME_URL
     description: |
       URL of the ACME CA directory endpoint.
-    default: https://acme-v01.api.letsencrypt.org/directory
+    default: https://acme-v02.api.letsencrypt.org/directory
 
   default_task_cpu_limit:
     env: CONCOURSE_DEFAULT_TASK_CPU_LIMIT


### PR DESCRIPTION
The AME API v1 is deprecated for more details check [this post](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380/4)
Concourse team already updated client in v5.8.0