### PR TITLE
certs: update default certificate location

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -69,7 +69,7 @@ properties:
     description: |
       A path to a directory on the instance to create the resource certificates
       volume from.
-    default: "/etc/ssl/certs"
+    default: "/usr/local/share/ca-certificates"
 
   drain_timeout:
     description: |


### PR DESCRIPTION
BOSH 270+ puts certificates in `/usr/local/share/ca-certificates` now (not sure when it changed), so update the default to align with BOSH defaults.

Worker example location using the `director.trusted_certs` field with `create-env`:

```
worker/504cefaf-3979-44c2-a7cb-3ad2096e2f1f:~$ ll /usr/local/share/ca-certificates
total 16
drwxr-xr-x 2 root root 4096 Feb 15 06:27 ./
drwxr-xr-x 4 root root 4096 Feb  3 14:09 ../
-rw-r--r-- 1 root root 2243 Feb 15 06:27 bosh-trusted-cert-1.crt
-rw-r--r-- 1 root root 2255 Feb 15 06:27 bosh-trusted-cert-2.crt
```