### PR TITLE
Support setting garden config.ini

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -16,6 +16,7 @@ templates:
   env.sh.erb: config/env.sh
   concourse.service: config/concourse.service
   worker_gateway_host_key.pub.erb: config/worker_gateway_host_key.pub
+  garden.ini.erb: config/garden.ini
 
 packages:
 - concourse
@@ -177,6 +178,12 @@ properties:
       Use the insecure Houdini Garden backend.
 
       If specified, the other garden.* properties have no effect.
+
+  garden.config_ini:
+    description: |
+      Contents of the Garden configuration. Use to customize the container runtime.
+      This may over-ride any other environment variables specified.
+      See: https://concourse-ci.org/concourse-worker.html#configuring-gdn-server
 
   garden.request_timeout:
     env: CONCOURSE_GARDEN_REQUEST_TIMEOUT

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -26,6 +26,10 @@ export CONCOURSE_TSA_PUBLIC_KEY=/var/vcap/jobs/worker/config/worker_gateway_host
   end
 -%>
 
+<% if_p("garden.config_ini") do |v| -%>
+export CONCOURSE_GARDEN_CONFIG=/var/vcap/jobs/worker/config/garden.ini
+<% end -%>
+
 <%
   # vim: ft=eruby
 

--- a/jobs/worker/templates/env.sh.erb.tmpl
+++ b/jobs/worker/templates/env.sh.erb.tmpl
@@ -26,6 +26,10 @@ export CONCOURSE_TSA_PUBLIC_KEY=/var/vcap/jobs/worker/config/worker_gateway_host
   end
 -%>
 
+<% if_p("garden.config_ini") do |v| -%>
+export CONCOURSE_GARDEN_CONFIG=/var/vcap/jobs/worker/config/garden.ini
+<% end -%>
+
 {{template "env_helpers.erb.tmpl" .}}
 
 {{- range $prop := .EnvProperties -}}

--- a/jobs/worker/templates/garden.ini.erb
+++ b/jobs/worker/templates/garden.ini.erb
@@ -1,0 +1,1 @@
+<%= p("garden.config_ini","") %>


### PR DESCRIPTION
This enables configuration of the garden `config.ini` as documented here: https://concourse-ci.org/concourse-worker.html#configuring-gdn-server

Sample results after configuration:
```
# cat config/env.sh
<...snip...>
export CONCOURSE_GARDEN_CONFIG=/var/vcap/jobs/worker/config/garden.ini
<...snip...>
# cat /var/vcap/jobs/worker/config/garden.ini
[server]
...garden settings here...
# ps -ef f
<...snip...>
root        4355       1  0 18:37 ?        Ss     0:00 /bin/bash /var/vcap/jobs/worker/bin/concourse_start
root        4380    4355  0 18:37 ?        Sl     0:00  \_ /var/vcap/packages/concourse/bin/concourse worker
root        4496    4380  0 18:37 ?        Sl     0:01      \_ gdn --config /var/vcap/jobs/worker/config/garden.ini server --bind-ip 127.0.0.1 --bind-port 7777 --depot /var/vcap/data/worker/work/depot --properties-path /var/vcap/data/worker/work/garde
<...snip...>
```

Note `gdn --config /var/vcap/jobs/worker/config/garden.ini ...` is now present in the execution.