### PR TITLE
Fix typo for COMPONENT_RUNNER_INTERVAL

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -783,8 +783,8 @@ properties:
       Maximum number of jobs to be scheduling at the same time.
     default: 32
 
-  runner_interval:
-    env: CONCOURSE_RUNNER_INTERVAL
+  component_runner_interval:
+    env: CONCOURSE_COMPONENT_RUNNER_INTERVAL
     description: |
       Interval on which runners are kicked off for builds, locks, scans, and checks
 

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -899,8 +899,8 @@ processes:
     CONCOURSE_ENABLE_REDACT_SECRETS: <%= env_flag(v).to_json %>
 <% end -%>
 
-<% if_p("runner_interval") do |v| -%>
-    CONCOURSE_RUNNER_INTERVAL: <%= env_flag(v).to_json %>
+<% if_p("component_runner_interval") do |v| -%>
+    CONCOURSE_COMPONENT_RUNNER_INTERVAL: <%= env_flag(v).to_json %>
 <% end -%>
 
 <% if_p("secrets.cache.duration") do |v| -%>


### PR DESCRIPTION
Signed-off-by: TJ Higgins <tj@architect.io>

blocked by: https://github.com/concourse/concourse/pull/5432