### PR TITLE
add `--concurrent-request-limit`

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -117,6 +117,12 @@ properties:
       The value to set for X-Frame-Options.
     default: deny
 
+  concurrent_request_limits:
+    env: CONCOURSE_CONCURRENT_REQUEST_LIMIT
+    description: |
+      Limit the number of concurrent requests to an API endpoint.
+    example: ListAllJobs:5
+
   log_level:
     env: CONCOURSE_LOG_LEVEL
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -263,6 +263,14 @@ processes:
     CONCOURSE_CLUSTER_NAME: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("component_runner_interval") do |v| -%>
+    CONCOURSE_COMPONENT_RUNNER_INTERVAL: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("concurrent_request_limits") do |v| -%>
+    CONCOURSE_CONCURRENT_REQUEST_LIMIT: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("config_rbac") do |v| -%>
     CONCOURSE_CONFIG_RBAC: <%= env_file_flag(v, "CONCOURSE_CONFIG_RBAC").to_json %>
 <% end -%>
@@ -897,10 +905,6 @@ processes:
 
 <% if_p("redact_secrets") do |v| -%>
     CONCOURSE_ENABLE_REDACT_SECRETS: <%= env_flag(v).to_json %>
-<% end -%>
-
-<% if_p("component_runner_interval") do |v| -%>
-    CONCOURSE_COMPONENT_RUNNER_INTERVAL: <%= env_flag(v).to_json %>
 <% end -%>
 
 <% if_p("secrets.cache.duration") do |v| -%>


### PR DESCRIPTION
concourse/concourse#5421

I decided to make the spec entry be the plural "limits" becase we will
definitely be adding support for specifying multiple limits separated by
commas in the future, and I don't want to have to change the parameter name at
that point.