### PR TITLE
ensure no invalid env vars

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1449,7 +1449,6 @@ properties:
     example:
       concourse: |
         ssh-rsa key key@pivotal.io
-    default: {}
 
   worker_gateway.log_level:
     env: CONCOURSE_TSA_LOG_LEVEL

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -168,7 +168,7 @@ properties:
       Disable remapping of user/group IDs in unprivileged volumes.
 
       For use in combination with 'garden.use_houdini'.
-    default: detect
+    default: false
 
   garden.use_houdini:
     env: CONCOURSE_GARDEN_USE_HOUDINI


### PR DESCRIPTION
We are [changing to a stricter version of the `go-flags` library](https://github.com/concourse/concourse/pull/5429/commits/a1f0e741c88a6b9ed71b6a8c8b15ba422d4f3152#diff-37aff102a57d3d7b797f152915a6dc16R129), which means that the concourse binary [will fail if any invalid env var configuration is passed](https://github.com/concourse/concourse/pull/5429/commits/1401898acc9b0927c36378a83a39ae228999f3c7#diff-d4becb815d0052a5c40f051b44a8e4f2R32-R34). This PR is necessary because it addresses two spots where the bosh release has been setting env vars to invalid values by default.