### PR TITLE
use a map for `--concurrent-request-limit`

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -117,6 +117,13 @@ properties:
       The value to set for X-Frame-Options.
     default: deny
 
+  concurrent_request_limits:
+    env: CONCOURSE_CONCURRENT_REQUEST_LIMIT
+    description: |
+      Limit the number of concurrent requests to an API endpoint.
+    example:
+      ListAllJobs: 5
+
   log_level:
     env: CONCOURSE_LOG_LEVEL
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -275,6 +275,10 @@ processes:
     CONCOURSE_COMPONENT_RUNNER_INTERVAL: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("concurrent_request_limits") do |v| -%>
+    CONCOURSE_CONCURRENT_REQUEST_LIMIT: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("config_rbac") do |v| -%>
     CONCOURSE_CONFIG_RBAC: <%= env_file_flag(v, "CONCOURSE_CONFIG_RBAC").to_json %>
 <% end -%>


### PR DESCRIPTION
Following @vito's [comment](https://github.com/concourse/concourse-bosh-release/pull/97#discussion_r420126963).