### PR TITLE
Conjur appliance url config

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1237,7 +1237,7 @@ properties:
     description: |
       The maximum time between retries when logging in or re-authing a secret.
 
-  conjur.appliance_interval:
+  conjur.appliance_url:
     env: CONCOURSE_CONJUR_APPLIANCE_URL
     description: |
       URL of the Conjur instance.
@@ -1249,6 +1249,10 @@ properties:
     env: CONCOURSE_CONJUR_CERT_FILE
     description: |
       Path to cert file used if conjur instance is using a self-signed cert.
+  conjur.ssl_certificate:
+    env: CONCOURSE_CONJUR_SSL_CERTIFICATE
+    description: |
+      Content of the SSL cert used if conjur instance is using a self-signed cert.
   conjur.auth.login:
     env: CONCOURSE_CONJUR_AUTHN_LOGIN
     description: |

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1245,14 +1245,11 @@ properties:
     env: CONCOURSE_CONJUR_ACCOUNT
     description: |
       Conjur account name.
-  conjur.cert_file:
-    env: CONCOURSE_CONJUR_CERT_FILE
+  conjur.tls.ca_cert:
+    type: certificate
+    env_fields: {certificate: {env_file: CONCOURSE_CONJUR_CERT_FILE}}
     description: |
-      Path to cert file used if conjur instance is using a self-signed cert.
-  conjur.ssl_certificate:
-    env: CONCOURSE_CONJUR_SSL_CERTIFICATE
-    description: |
-      Content of the SSL cert used if conjur instance is using a self-signed cert.
+      A PEM-encoded CA cert to use to verify the Conjur server SSL cert. 
   conjur.auth.login:
     env: CONCOURSE_CONJUR_AUTHN_LOGIN
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -303,10 +303,6 @@ processes:
     CONCOURSE_CONJUR_AUTHN_TOKEN_FILE: <%= env_flag(v).to_json %>
 <% end -%>
 
-<% if_p("conjur.cert_file") do |v| -%>
-    CONCOURSE_CONJUR_CERT_FILE: <%= env_flag(v).to_json %>
-<% end -%>
-
 <% if_p("conjur.pipeline_secret_template") do |v| -%>
     CONCOURSE_CONJUR_PIPELINE_SECRET_TEMPLATE: <%= env_flag(v).to_json %>
 <% end -%>
@@ -315,12 +311,12 @@ processes:
     CONCOURSE_CONJUR_SECRET_TEMPLATE: <%= env_flag(v).to_json %>
 <% end -%>
 
-<% if_p("conjur.ssl_certificate") do |v| -%>
-    CONCOURSE_CONJUR_SSL_CERTIFICATE: <%= env_flag(v).to_json %>
-<% end -%>
-
 <% if_p("conjur.team_secret_template") do |v| -%>
     CONCOURSE_CONJUR_TEAM_SECRET_TEMPLATE: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("conjur.tls.ca_cert.certificate") do |v| -%>
+    CONCOURSE_CONJUR_CERT_FILE: <%= env_file_flag(v, "CONCOURSE_CONJUR_CERT_FILE").to_json %>
 <% end -%>
 
 <% if_p("container_placement_strategy") do |v| -%>

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -287,7 +287,7 @@ processes:
     CONCOURSE_CONJUR_ACCOUNT: <%= env_flag(v).to_json %>
 <% end -%>
 
-<% if_p("conjur.appliance_interval") do |v| -%>
+<% if_p("conjur.appliance_url") do |v| -%>
     CONCOURSE_CONJUR_APPLIANCE_URL: <%= env_flag(v).to_json %>
 <% end -%>
 
@@ -313,6 +313,10 @@ processes:
 
 <% if_p("conjur.secret_template") do |v| -%>
     CONCOURSE_CONJUR_SECRET_TEMPLATE: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("conjur.ssl_certificate") do |v| -%>
+    CONCOURSE_CONJUR_SSL_CERTIFICATE: <%= env_flag(v).to_json %>
 <% end -%>
 
 <% if_p("conjur.team_secret_template") do |v| -%>
@@ -855,10 +859,6 @@ processes:
     CONCOURSE_NEWRELIC_API_KEY: <%= env_flag(v).to_json %>
 <% end -%>
 
-<% if_p("newrelic.url") do |v| -%>
-    CONCOURSE_NEWRELIC_INSIGHTS_API_URL: <%= env_flag(v).to_json %>
-<% end -%>
-
 <% if_p("newrelic.batch_duration") do |v| -%>
     CONCOURSE_NEWRELIC_BATCH_DURATION: <%= env_flag(v).to_json %>
 <% end -%>
@@ -873,6 +873,10 @@ processes:
 
 <% if_p("newrelic.service_prefix") do |v| -%>
     CONCOURSE_NEWRELIC_SERVICE_PREFIX: <%= env_flag(v).to_json %>
+<% end -%>
+
+<% if_p("newrelic.url") do |v| -%>
+    CONCOURSE_NEWRELIC_INSIGHTS_API_URL: <%= env_flag(v).to_json %>
 <% end -%>
 
 <% if_p("old_encryption_key") do |v| -%>

--- a/jobs/web/templates/pre_start.erb
+++ b/jobs/web/templates/pre_start.erb
@@ -51,6 +51,9 @@ mkdir -p /var/vcap/jobs/web/config/env
 <% if_p("config_rbac") do |v| -%>
 <%= env_file_writer(v, "CONCOURSE_CONFIG_RBAC") %>
 <% end -%>
+<% if_p("conjur.tls.ca_cert.certificate") do |v| -%>
+<%= env_file_writer(v, "CONCOURSE_CONJUR_CERT_FILE") %>
+<% end -%>
 <% if_p("credhub.tls.ca_cert.certificate") do |v| -%>
 <%= env_file_writer(v, "CONCOURSE_CREDHUB_CA_CERT") %>
 <% end -%>


### PR DESCRIPTION
Fixed the web spec from `conjur.appliance_interval` to `conjur.appliance_url`.
Also added a web spec for `conjur.ssl_certificate` so you can pass the certificate in directly instead of providing it as a file.