### PR TITLE
Add max checks flag for v6.3.0

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -841,10 +841,9 @@ properties:
   max_checks_per_second:
     env: CONCOURSE_MAX_CHECKS_PER_SECOND
     description: |
-      Maximum number of checks that can run in one second. If not specified,
-      this will be calculated as (# of resources)/(resource checking interval).
-      -1 value will remove this maximum limit of checks per second.
-    default: 0
+      Maximum number of checks that can be started per second. If not
+      specified, this will be calculated as (# of resources)/(resource checking
+      interval). -1 value will remove this maximum limit of checks per second.
 
   default_check_interval:
     env: CONCOURSE_RESOURCE_CHECKING_INTERVAL

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -838,6 +838,14 @@ properties:
       Time limit on checking for new versions of resources.
     default: 1h
 
+  max_checks_per_second:
+    env: CONCOURSE_MAX_CHECKS_PER_SECOND
+    description: |
+      Maximum number of checks that can run in one second. If not specified,
+      this will be calculated as (# of resources)/(resource checking interval).
+      -1 value will remove this maximum limit of checks per second.
+    default: 0
+
   default_check_interval:
     env: CONCOURSE_RESOURCE_CHECKING_INTERVAL
     description: |

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -844,7 +844,7 @@ properties:
       Maximum number of checks that can be started per second. If not
       specified, this will be calculated as (# of resources)/(resource checking
       interval). -1 value will remove this maximum limit of checks per second.
-    example: 0
+    example: 100
 
   default_check_interval:
     env: CONCOURSE_RESOURCE_CHECKING_INTERVAL

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -844,6 +844,7 @@ properties:
       Maximum number of checks that can be started per second. If not
       specified, this will be calculated as (# of resources)/(resource checking
       interval). -1 value will remove this maximum limit of checks per second.
+    example: 0
 
   default_check_interval:
     env: CONCOURSE_RESOURCE_CHECKING_INTERVAL

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -823,6 +823,10 @@ processes:
     CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("max_checks_per_second") do |v| -%>
+    CONCOURSE_MAX_CHECKS_PER_SECOND: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("metrics_buffer_size") do |v| -%>
     CONCOURSE_METRICS_BUFFER_SIZE: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
This PR replaces https://github.com/concourse/concourse-bosh-release/pull/110. It adds the `max-checks-per-second` flag that was added in the v6.3.0 release. 