### PR TITLE
add support for new containerd flags

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -97,11 +97,6 @@ properties:
     description: |
       Maximum number of containers which can be swept in parallel.
 
-  container_network_pool:
-    env: CONCOURSE_CONTAINER_NETWORK_POOL
-    description: |
-      Network range to use for dynamically allocated container subnets.
-
   volume_sweeper_max_in_flight:
     env: CONCOURSE_VOLUME_SWEEPER_MAX_IN_FLIGHT
     description: |
@@ -180,7 +175,6 @@ properties:
     description: |
       Container runtime for worker. Possible values are "guardian", "containerd", and "houdini".
       Please note that Houdini is insecure and does not run tasks in containers.
-    default: guardian
 
   garden.config_ini:
     description: |
@@ -225,6 +219,48 @@ properties:
     description: |
       Deprecated in favor of container_network_pool.
     default: 10.254.0.0/22
+
+  containerd.bin:
+    env: CONCOURSE_CONTAINERD_BIN
+    description: |
+      Path to a containerd executable (non-absolute names get resolved from $PATH).
+
+  containerd.config:
+    env: CONCOURSE_CONTAINERD_CONFIG
+    description: |
+      Path to a config file to use for the Containerd daemon.
+
+  containerd.dnsProxyEnable:
+    env: CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE
+    description: |
+      Enable a proxy DNS server for Garden
+
+  containerd.dnsServers:
+    env: CONCOURSE_CONTAINERD_DNS_SERVER
+    description: |
+      List of DNS server IP addresses to use instead of automatically determined servers.
+
+  containerd.restrictedNetworks:
+    env: CONCOURSE_CONTAINERD_RESTRICTED_NETWORK
+    description: |
+      List of network ranges to which traffic from containers will be restricted.
+
+  containerd.maxContainers:
+    env: CONCOURSE_CONTAINERD_MAX_CONTAINERS
+    description: |
+      Max container capacity. 0 means no limit.
+
+  containerd.networkPool:
+    env: CONCOURSE_CONTAINERD_NETWORK_POOL
+    description: |
+      Network range to use for dynamically allocated container subnets, defaults to "10.80.0.0/16"
+
+  containerd.requestTimeout:
+    env: CONCOURSE_CONTAINERD_REQUEST_TIMEOUT
+    description: |
+      Time to wait for requests to Containerd to complete. 0 means no timeout.
+
+
 
   debug.bind_ip:
     env: CONCOURSE_DEBUG_BIND_IP

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -170,11 +170,12 @@ properties:
       For use in combination with 'runtime.type=houdini'.
     default: false
 
-  runtime.type:
-    env: CONCOURSE_RUNTIME_TYPE
+  runtime:
+    env: CONCOURSE_RUNTIME
     description: |
       Container runtime for worker. Possible values are "guardian", "containerd", and "houdini".
       Please note that Houdini is insecure and does not run tasks in containers.
+    example: guardian
 
   garden.config_ini:
     description: |

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -172,15 +172,15 @@ properties:
     description: |
       Disable remapping of user/group IDs in unprivileged volumes.
 
-      For use in combination with 'garden.use_houdini'.
+      For use in combination with 'runtime.type=houdini'.
     default: false
 
-  garden.use_houdini:
-    env: CONCOURSE_GARDEN_USE_HOUDINI
+  runtime.type:
+    env: CONCOURSE_RUNTIME_TYPE
     description: |
-      Use the insecure Houdini Garden backend.
-
-      If specified, the other garden.* properties have no effect.
+      Container runtime for worker. Possible values are "guardian", "containerd", and "houdini".
+      Please note that Houdini is insecure and does not run tasks in containers.
+    default: guardian
 
   garden.config_ini:
     description: |

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -230,32 +230,32 @@ properties:
     description: |
       Path to a config file to use for the Containerd daemon.
 
-  containerd.dnsProxyEnable:
+  containerd.dns_proxy_enable:
     env: CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE
     description: |
       Enable a proxy DNS server for Garden
 
-  containerd.dnsServers:
+  containerd.dns_servers:
     env: CONCOURSE_CONTAINERD_DNS_SERVER
     description: |
       List of DNS server IP addresses to use instead of automatically determined servers.
 
-  containerd.restrictedNetworks:
+  containerd.restricted_networks:
     env: CONCOURSE_CONTAINERD_RESTRICTED_NETWORK
     description: |
       List of network ranges to which traffic from containers will be restricted.
 
-  containerd.maxContainers:
+  containerd.max_containers:
     env: CONCOURSE_CONTAINERD_MAX_CONTAINERS
     description: |
       Max container capacity. 0 means no limit.
 
-  containerd.networkPool:
+  containerd.network_pool:
     env: CONCOURSE_CONTAINERD_NETWORK_POOL
     description: |
       Network range to use for dynamically allocated container subnets, defaults to "10.80.0.0/16"
 
-  containerd.requestTimeout:
+  containerd.request_timeout:
     env: CONCOURSE_CONTAINERD_REQUEST_TIMEOUT
     description: |
       Time to wait for requests to Containerd to complete. 0 means no timeout.

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -186,8 +186,8 @@ export CONCOURSE_LOG_LEVEL=<%= esc(env_flag(v)) %>
 export no_proxy=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("runtime.type") do |v| -%>
-export CONCOURSE_RUNTIME_TYPE=<%= esc(env_flag(v)) %>
+<% if_p("runtime") do |v| -%>
+export CONCOURSE_RUNTIME=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("sweep_interval") do |v| -%>

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -106,6 +106,10 @@ export CONCOURSE_EPHEMERAL=<%= esc(env_flag(v)) %>
 export CONCOURSE_EXTERNAL_GARDEN_URL=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("runtime.type") do |v| -%>
+export CONCOURSE_RUNTIME_TYPE=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("garden.allow_host_access") do |v| -%>
 export CONCOURSE_GARDEN_ALLOW_HOST_ACCESS=<%= esc(env_flag(v)) %>
 <% end -%>
@@ -128,10 +132,6 @@ export CONCOURSE_GARDEN_NETWORK_POOL=<%= esc(env_flag(v)) %>
 
 <% if_p("garden.request_timeout") do |v| -%>
 export CONCOURSE_GARDEN_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.use_houdini") do |v| -%>
-export CONCOURSE_GARDEN_USE_HOUDINI=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("healthcheck.bind_ip") do |v| -%>

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -94,27 +94,27 @@ export CONCOURSE_CONTAINERD_BIN=<%= esc(env_flag(v)) %>
 export CONCOURSE_CONTAINERD_CONFIG=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.dnsProxyEnable") do |v| -%>
+<% if_p("containerd.dns_proxy_enable") do |v| -%>
 export CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.dnsServers") do |v| -%>
+<% if_p("containerd.dns_servers") do |v| -%>
 export CONCOURSE_CONTAINERD_DNS_SERVER=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.maxContainers") do |v| -%>
+<% if_p("containerd.max_containers") do |v| -%>
 export CONCOURSE_CONTAINERD_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.networkPool") do |v| -%>
+<% if_p("containerd.network_pool") do |v| -%>
 export CONCOURSE_CONTAINERD_NETWORK_POOL=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.requestTimeout") do |v| -%>
+<% if_p("containerd.request_timeout") do |v| -%>
 export CONCOURSE_CONTAINERD_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.restrictedNetworks") do |v| -%>
+<% if_p("containerd.restricted_networks") do |v| -%>
 export CONCOURSE_CONTAINERD_RESTRICTED_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>
 

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -82,12 +82,40 @@ export CONCOURSE_CERTS_DIR=<%= esc(env_flag(v)) %>
 export CONCOURSE_CONNECTION_DRAIN_TIMEOUT=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("container_network_pool") do |v| -%>
-export CONCOURSE_CONTAINER_NETWORK_POOL=<%= esc(env_flag(v)) %>
-<% end -%>
-
 <% if_p("container_sweeper_max_in_flight") do |v| -%>
 export CONCOURSE_CONTAINER_SWEEPER_MAX_IN_FLIGHT=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.bin") do |v| -%>
+export CONCOURSE_CONTAINERD_BIN=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.config") do |v| -%>
+export CONCOURSE_CONTAINERD_CONFIG=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.dnsProxyEnable") do |v| -%>
+export CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.dnsServers") do |v| -%>
+export CONCOURSE_CONTAINERD_DNS_SERVER=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.maxContainers") do |v| -%>
+export CONCOURSE_CONTAINERD_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.networkPool") do |v| -%>
+export CONCOURSE_CONTAINERD_NETWORK_POOL=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.requestTimeout") do |v| -%>
+export CONCOURSE_CONTAINERD_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.restrictedNetworks") do |v| -%>
+export CONCOURSE_CONTAINERD_RESTRICTED_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("debug.bind_ip") do |v| -%>
@@ -104,10 +132,6 @@ export CONCOURSE_EPHEMERAL=<%= esc(env_flag(v)) %>
 
 <% if_p("external_garden_url") do |v| -%>
 export CONCOURSE_EXTERNAL_GARDEN_URL=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("runtime.type") do |v| -%>
-export CONCOURSE_RUNTIME_TYPE=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("garden.allow_host_access") do |v| -%>
@@ -160,6 +184,10 @@ export CONCOURSE_LOG_LEVEL=<%= esc(env_flag(v)) %>
 
 <% if_p("no_proxy") do |v| -%>
 export no_proxy=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("runtime.type") do |v| -%>
+export CONCOURSE_RUNTIME_TYPE=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("sweep_interval") do |v| -%>


### PR DESCRIPTION
# Existing Issue
Part of the PR concourse/concourse#5911, which addresses issue concourse/concourse#5407.

# Changes proposed in this pull request
* replace useContainerd and useHoudining with ~~runtime.type~~ runtime
* remove CONCOURSE_CONTAINER_NETWORK_POOL - this is covered by CONCOURSE_GARDEN_NETWORK_POOL and CONCOURSE_CONTAINERD_NETWORK_POOL
* add support for finalized containerd flags

**Note to reviewer** 

I have not been able to verify how BOSH [templates](https://bosh.io/docs/jobs/#templates) work for spec values that can be arrays e.g. garden.dns_servers, containerd.dns_servers.

For example, `garden.dns_servers` in the worker spec can be provided multiple values, and is being referenced in `env.sh.rb` with the following:

```
<% if_p("garden.dns_servers") do |v| -%>
export CONCOURSE_GARDEN_DNS_SERVER=<%= esc(env_flag(v)) %>
<% end -%>
```

I followed the same for `containerd` worker fields that can have multiple values but have not figured out how to validate if the value is indeed being exported multiple times.