### PR TITLE
web: add CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1499,6 +1499,12 @@ properties:
       Interval on which to register workers with the ATC.
     default: 30s
 
+  worker_gateway.garden_request_timeout:
+    env: CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT
+    description: |
+      How long to wait for requests to Garden to complete. 0 means no timeout.
+    example: 5m
+
   worker_gateway.bind_port:
     env: CONCOURSE_TSA_BIND_PORT
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -1127,6 +1127,10 @@ processes:
     CONCOURSE_TSA_CLIENT_SECRET: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("worker_gateway.garden_request_timeout") do |v| -%>
+    CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("worker_gateway.heartbeat_interval") do |v| -%>
     CONCOURSE_TSA_HEARTBEAT_INTERVAL: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT was added in
https://github.com/concourse/concourse/pull/5845/. This PR makes it configurable in the web spec.