### PR TITLE
Add a runtime flag to spec files

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -178,12 +178,14 @@ properties:
     example: guardian
 
   garden.config_ini:
+    runtime: guardian
     description: |
       Contents of the Garden configuration. Use to customize the container runtime.
       This may over-ride any other environment variables specified.
       See: https://concourse-ci.org/concourse-worker.html#configuring-gdn-server
 
   garden.request_timeout:
+    runtime: guardian
     env: CONCOURSE_GARDEN_REQUEST_TIMEOUT
     description: |
       How long to wait for requests to Garden to complete, in Go duration format (48h = 48 hours).
@@ -191,12 +193,14 @@ properties:
     example: 5m
 
   garden.deny_networks:
+    runtime: guardian
     env: CONCOURSE_GARDEN_DENY_NETWORK
     description: |
       Network ranges to which traffic from containers will be denied.
     example: []
 
   garden.dns_servers:
+    runtime: guardian
     env: CONCOURSE_GARDEN_DNS_SERVER
     description: |
       DNS servers IP addresses to use instead of automatically
@@ -204,59 +208,70 @@ properties:
     example: []
 
   garden.allow_host_access:
+    runtime: guardian
     env: CONCOURSE_GARDEN_ALLOW_HOST_ACCESS
     description: |
       Allow containers to reach the worker VM's network.
     default: false
 
   garden.max_containers:
+    runtime: guardian
     env: CONCOURSE_GARDEN_MAX_CONTAINERS
     description: |
       Maximum container capacity to advertise. Note: Not tested over 250.
     default: 250
 
   garden.network_pool:
+    runtime: guardian
     env: CONCOURSE_GARDEN_NETWORK_POOL
     description: |
       Deprecated in favor of container_network_pool.
     default: 10.254.0.0/22
 
   containerd.bin:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_BIN
     description: |
       Path to a containerd executable (non-absolute names get resolved from $PATH).
 
   containerd.config:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_CONFIG
     description: |
       Path to a config file to use for the Containerd daemon.
 
   containerd.dns_proxy_enable:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE
     description: |
       Enable a proxy DNS server for Garden
 
   containerd.dns_servers:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_DNS_SERVER
     description: |
       List of DNS server IP addresses to use instead of automatically determined servers.
 
   containerd.restricted_networks:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_RESTRICTED_NETWORK
     description: |
       List of network ranges to which traffic from containers will be restricted.
 
   containerd.max_containers:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_MAX_CONTAINERS
     description: |
       Max container capacity. 0 means no limit.
 
   containerd.network_pool:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_NETWORK_POOL
     description: |
       Network range to use for dynamically allocated container subnets, defaults to "10.80.0.0/16"
 
   containerd.request_timeout:
+    runtime: containerd
     env: CONCOURSE_CONTAINERD_REQUEST_TIMEOUT
     description: |
       Time to wait for requests to Containerd to complete. 0 means no timeout.

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -6,6 +6,7 @@
   end
 
   name_prefix = spec.id.split("-")[0]
+  runtime_options = p("runtime", "guardian")
 -%>
 export CONCOURSE_NAME="<%= name_prefix %>-$(hostname | cut -d '-' -f 2-)"
 
@@ -86,38 +87,6 @@ export CONCOURSE_CONNECTION_DRAIN_TIMEOUT=<%= esc(env_flag(v)) %>
 export CONCOURSE_CONTAINER_SWEEPER_MAX_IN_FLIGHT=<%= esc(env_flag(v)) %>
 <% end -%>
 
-<% if_p("containerd.bin") do |v| -%>
-export CONCOURSE_CONTAINERD_BIN=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.config") do |v| -%>
-export CONCOURSE_CONTAINERD_CONFIG=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.dns_proxy_enable") do |v| -%>
-export CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.dns_servers") do |v| -%>
-export CONCOURSE_CONTAINERD_DNS_SERVER=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.max_containers") do |v| -%>
-export CONCOURSE_CONTAINERD_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.network_pool") do |v| -%>
-export CONCOURSE_CONTAINERD_NETWORK_POOL=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.request_timeout") do |v| -%>
-export CONCOURSE_CONTAINERD_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("containerd.restricted_networks") do |v| -%>
-export CONCOURSE_CONTAINERD_RESTRICTED_NETWORK=<%= esc(env_flag(v)) %>
-<% end -%>
-
 <% if_p("debug.bind_ip") do |v| -%>
 export CONCOURSE_DEBUG_BIND_IP=<%= esc(env_flag(v)) %>
 <% end -%>
@@ -132,30 +101,6 @@ export CONCOURSE_EPHEMERAL=<%= esc(env_flag(v)) %>
 
 <% if_p("external_garden_url") do |v| -%>
 export CONCOURSE_EXTERNAL_GARDEN_URL=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.allow_host_access") do |v| -%>
-export CONCOURSE_GARDEN_ALLOW_HOST_ACCESS=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.deny_networks") do |v| -%>
-export CONCOURSE_GARDEN_DENY_NETWORK=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.dns_servers") do |v| -%>
-export CONCOURSE_GARDEN_DNS_SERVER=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.max_containers") do |v| -%>
-export CONCOURSE_GARDEN_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.network_pool") do |v| -%>
-export CONCOURSE_GARDEN_NETWORK_POOL=<%= esc(env_flag(v)) %>
-<% end -%>
-
-<% if_p("garden.request_timeout") do |v| -%>
-export CONCOURSE_GARDEN_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
 <% end -%>
 
 <% if_p("healthcheck.bind_ip") do |v| -%>
@@ -222,3 +167,62 @@ export CONCOURSE_REBALANCE_INTERVAL=<%= esc(env_flag(v)) %>
 export CONCOURSE_TSA_WORKER_PRIVATE_KEY=<%= esc(env_file_flag(v, "CONCOURSE_TSA_WORKER_PRIVATE_KEY")) %>
 <% end -%>
 
+<% if runtime_options == "guardian" %>
+  <% if_p("garden.allow_host_access") do |v| -%>
+  export CONCOURSE_GARDEN_ALLOW_HOST_ACCESS=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("garden.deny_networks") do |v| -%>
+  export CONCOURSE_GARDEN_DENY_NETWORK=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("garden.dns_servers") do |v| -%>
+  export CONCOURSE_GARDEN_DNS_SERVER=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("garden.max_containers") do |v| -%>
+  export CONCOURSE_GARDEN_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("garden.network_pool") do |v| -%>
+  export CONCOURSE_GARDEN_NETWORK_POOL=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("garden.request_timeout") do |v| -%>
+  export CONCOURSE_GARDEN_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
+  <% end -%>
+<% end %>
+
+<% if runtime_options == "containerd" %>
+  <% if_p("containerd.bin") do |v| -%>
+  export CONCOURSE_CONTAINERD_BIN=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.config") do |v| -%>
+  export CONCOURSE_CONTAINERD_CONFIG=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.dns_proxy_enable") do |v| -%>
+  export CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.dns_servers") do |v| -%>
+  export CONCOURSE_CONTAINERD_DNS_SERVER=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.max_containers") do |v| -%>
+  export CONCOURSE_CONTAINERD_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.network_pool") do |v| -%>
+  export CONCOURSE_CONTAINERD_NETWORK_POOL=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.request_timeout") do |v| -%>
+  export CONCOURSE_CONTAINERD_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
+  <% end -%>
+
+  <% if_p("containerd.restricted_networks") do |v| -%>
+  export CONCOURSE_CONTAINERD_RESTRICTED_NETWORK=<%= esc(env_flag(v)) %>
+  <% end -%>
+<% end %>

--- a/jobs/worker/templates/env.sh.erb.tmpl
+++ b/jobs/worker/templates/env.sh.erb.tmpl
@@ -6,6 +6,7 @@
   end
 
   name_prefix = spec.id.split("-")[0]
+  runtime_options = p("runtime", "guardian")
 -%>
 export CONCOURSE_NAME="<%= name_prefix %>-$(hostname | cut -d '-' -f 2-)"
 
@@ -32,7 +33,7 @@ export CONCOURSE_GARDEN_CONFIG=/var/vcap/jobs/worker/config/garden.ini
 
 {{template "env_helpers.erb.tmpl" .}}
 
-{{- range $prop := .EnvProperties -}}
+{{- range $prop := .EnvProperties.ForRuntime "" -}}
 {{- if $prop.Env -}}
 <% if_p("{{$prop.Name}}") do |v| -%>
 export {{$prop.Env}}=<%= esc(env_flag(v)) %>
@@ -47,3 +48,23 @@ export {{$prop.EnvFile}}=<%= esc(env_file_flag(v, "{{$prop.EnvFile}}")) %>
 
 {{ end -}}
 {{- end -}}
+
+<% if runtime_options == "guardian" %>
+{{- range $prop := .EnvProperties.ForRuntime "guardian" }}
+{{- if $prop.Env }}
+  <% if_p("{{$prop.Name}}") do |v| -%>
+  export {{$prop.Env}}=<%= esc(env_flag(v)) %>
+  <% end -%>
+{{ end -}}
+{{- end -}}
+<% end %>
+
+<% if runtime_options == "containerd" %>
+{{- range $prop := .EnvProperties.ForRuntime "containerd" }}
+{{- if $prop.Env }}
+  <% if_p("{{$prop.Name}}") do |v| -%>
+  export {{$prop.Env}}=<%= esc(env_flag(v)) %>
+  <% end -%>
+{{ end -}}
+{{- end -}}
+<% end %>

--- a/src/envgen/ctx.go
+++ b/src/envgen/ctx.go
@@ -3,10 +3,22 @@ package main
 type TemplateContext struct {
 	Name string
 
-	EnvProperties []EnvProperty
+	EnvProperties EnvProperties
 }
+
+type EnvProperties []EnvProperty
 
 type EnvProperty struct {
 	Name string
 	EnvConfig
+}
+
+func (ep EnvProperties) ForRuntime(runtime string) []EnvProperty {
+	filtered := []EnvProperty{}
+	for _, v := range ep {
+		if v.EnvConfig.Runtime == runtime {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
 }

--- a/src/envgen/spec.go
+++ b/src/envgen/spec.go
@@ -13,4 +13,5 @@ type Property struct {
 type EnvConfig struct {
 	Env     string `yaml:"env"`
 	EnvFile string `yaml:"env_file"`
+	Runtime string `yaml:"runtime"`
 }


### PR DESCRIPTION
Only one of CONCOURSE_CONTAINERD_* and CONCOURSE_GARDEN_* sets of
options should be set. Add a flag in the spec file that the envgen
helper uses to generate ERB files that correctly represent this need.
Defaults to Guardian since that is the implicit default in Concourse.

Fixes #115

Questions:
* In the README it recommends `don't define a default value that mirrors a default set by the Concourse binary` but I don't really see any way to do this without mirroring the default runtime
* I only added the env vars for a specific runtime since (currently), the only runtime specific configuration is env vars. Should I include the env files too just in case someone adds one in the future?