### PR TITLE
add CONCOURSE_CONTAINERD_INIT_BIN

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -258,7 +258,11 @@ properties:
     description: |
       Time to wait for requests to Containerd to complete. 0 means no timeout.
 
-
+  containerd.init_bin:
+    env: CONCOURSE_CONTAINERD_INIT_BIN
+    description: |
+      Path to a dumb init executable. For BOSH this defaults to /var/vcap/packages/concourse/bin/init when containerd
+      is selected as the runtime.
 
   debug.bind_ip:
     env: CONCOURSE_DEBUG_BIND_IP

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -118,6 +118,18 @@ export CONCOURSE_CONTAINERD_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
 export CONCOURSE_CONTAINERD_RESTRICTED_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>
 
+#TODO: When the Concourse binary starts defaulting to containerd in the future the if condition should also check for
+#the case where runtime is nil (i.e. defaults to containerd without being specified)
+<%
+  if_p("runtime") do |v|
+    if v == "containerd"
+-%>
+export CONCOURSE_CONTAINERD_INIT_BIN=<%= p("containerd.init_bin", "/var/vcap/packages/concourse/bin/init") %>
+<%
+    end
+  end
+-%>
+
 <% if_p("debug.bind_ip") do |v| -%>
 export CONCOURSE_DEBUG_BIND_IP=<%= esc(env_flag(v)) %>
 <% end -%>


### PR DESCRIPTION
**Part of:** concourse/concourse#5984

**Changed in this PR**
The CONCOURSE_CONTAINERD_INIT_BIN needs to point to /var/vcap/packages/concourse/bin/init specifically on BOSH when running containerd.

This should only be set when using containerd as the runtime. Currently, that means checking if the runtime property is set to "containerd" explicitly. 

In the future when the concourse binary will default to containerd when no runtime property is set we also need to check if runtime is nil.

**Notes to reviewer**
This will be easier to test with the `bosh-template` gem.

`gem install bosh-template`

**Scenario 1**

`bosh-template jobs/worker/templates/env.sh.erb --context '{"id":"abc123-123abc", "properties":{"runtime":"containerd", "containerd": {"init_bin_path":"something"}}}'`

Result:  
`export CONCOURSE_CONTAINERD_INIT_BIN=something`

**Scenario 2**

`bosh-template jobs/worker/templates/env.sh.erb --context '{"id":"abc123-123abc", "properties":{"runtime":"containerd"}}'`

Result: 
`export CONCOURSE_CONTAINERD_INIT_BIN/var/vcap/packages/concourse/bin/init`

**Scenario 3**
bosh-template jobs/worker/templates/env.sh.erb --context '{"id":"abc123-123abc", "properties":{}}'
Result:
`CONCOURSE_CONTAINERD_INIT_BIN` will not be set