### PR TITLE
add feature flag for instanced pipelines

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -902,6 +902,11 @@ properties:
     description: |
       Enable the experimental across step to be used in jobs. The API is subject to change.
 
+  enable_pipeline_instances:
+    env: CONCOURSE_ENABLE_PIPELINE_INSTANCES
+    description: |
+      Enable the creation of instanced pipelines.
+
   streaming_artifacts_compression:
     env: CONCOURSE_STREAMING_ARTIFACTS_COMPRESSION
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -407,6 +407,10 @@ processes:
     CONCOURSE_ENABLE_GLOBAL_RESOURCES: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("enable_pipeline_instances") do |v| -%>
+    CONCOURSE_ENABLE_PIPELINE_INSTANCES: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("enable_rerun_when_worker_disappears") do |v| -%>
     CONCOURSE_ENABLE_RERUN_WHEN_WORKER_DISAPPEARS: <%= env_flag(v).to_json %>
 <% end -%>
@@ -697,10 +701,6 @@ processes:
 
 <% if_p("lets_encrypt.enabled") do |v| -%>
     CONCOURSE_ENABLE_LETS_ENCRYPT: <%= env_flag(v).to_json %>
-<% end -%>
-
-<% if_p("lidar_checker_interval") do |v| -%>
-    CONCOURSE_LIDAR_CHECKER_INTERVAL: <%= env_flag(v).to_json %>
 <% end -%>
 
 <% if_p("lidar_scanner_interval") do |v| -%>


### PR DESCRIPTION
also, removes the lidar_checker_interval which was removed from the spec
but not from the template

side note - #123 makes it so that scripts/generate-job-templates will
always produce a diff, which is unfortunate

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>