### PR TITLE
add godebug configs

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -100,6 +100,11 @@ properties:
       Port on which to listen for the pprof debugger endpoints.
     default: 8079
 
+  debug.godebug:
+    env: GODEBUG
+    description: |
+      A list of name=value pairs separated by commas, where each name is a runtime debugging facility.
+
   external_url:
     env: CONCOURSE_EXTERNAL_URL
     description: |

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -391,6 +391,10 @@ processes:
     CONCOURSE_DEBUG_BIND_PORT: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("debug.godebug") do |v| -%>
+    GODEBUG: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("default_check_interval") do |v| -%>
     CONCOURSE_RESOURCE_CHECKING_INTERVAL: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
fixes #127 

alternatively if we want to limit the debug flags option we could do sth like

if enable_godebug_cn_matching
  GODEBUG: x509ignoreCN=0

to hardcode the name/value pair. WDYT?
