### PR TITLE
expose baggageclaim bind_ip this would fix #140

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -156,6 +156,13 @@ properties:
       Driver to use for the volume store. One of detect, overlay, btrfs, or naive.
     default: detect
 
+  baggageclaim.bind_ip:
+    env: CONCOURSE_BAGGAGECLAIM_BIND_IP
+    description: |
+      IP on which Baggageclaim should listen for HTTP traffic.
+      When p2p is enabled this needs to be set to 0.0.0.0
+    example: 0.0.0.0
+
   baggageclaim.bind_port:
     env: CONCOURSE_BAGGAGECLAIM_BIND_PORT
     description: |

--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -161,7 +161,7 @@ properties:
     description: |
       IP on which Baggageclaim should listen for HTTP traffic.
       When p2p is enabled this needs to be set to 0.0.0.0
-    example: 0.0.0.0
+    default: 127.0.0.1
 
   baggageclaim.bind_port:
     env: CONCOURSE_BAGGAGECLAIM_BIND_PORT

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -77,6 +77,10 @@ export CONCOURSE_CONTAINERD_CNI_PLUGINS_DIR=<%= p("containerd.cni_plugins_dir", 
   end
 -%>
 
+<% if_p("baggageclaim.bind_ip") do |v| -%>
+export CONCOURSE_BAGGAGECLAIM_BIND_IP=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("baggageclaim.bind_port") do |v| -%>
 export CONCOURSE_BAGGAGECLAIM_BIND_PORT=<%= esc(env_flag(v)) %>
 <% end -%>


### PR DESCRIPTION
exposing `CONCOURSE_BAGGAGECLAIM_BIND_IP`
this is needed when trying out the experimental p2p volume streaming