### PR TITLE
Make bbr backup more resilent

### DIFF
--- a/jobs/bbr-atcdb/spec
+++ b/jobs/bbr-atcdb/spec
@@ -4,6 +4,7 @@ name: bbr-atcdb
 
 templates:
   config.json.erb: config/config.json
+  connection_data.erb: config/connection_data
   backup.sh.erb: bin/bbr/backup
   restore.sh.erb: bin/bbr/restore
 

--- a/jobs/bbr-atcdb/templates/backup.sh.erb
+++ b/jobs/bbr-atcdb/templates/backup.sh.erb
@@ -3,9 +3,35 @@ set -e
 
 JOB_PATH="/var/vcap/jobs/bbr-atcdb"
 
+source ${JOB_PATH}/config/connection_data
+
 # Anything placed in the BBR_ARTIFACT_DIRECTORY by the backup script will be available to the restore script at restore time.
 # The BBR CLI is responsible for setting the BBR_ARTIFACT_DIRECTORY
 BBR_ARTIFACT_FILE_PATH="${BBR_ARTIFACT_DIRECTORY}/atcdb-artifact-file"
 CONFIG_PATH="${JOB_PATH}/config/config.json"
+PAUSE_WEB_COMPONENTS="UPDATE components SET paused = true WHERE name IN ('tracker','collector_pipelines');"
+UNPAUSE_WEB_COMPONENTS="UPDATE components SET paused = false WHERE name IN ('tracker','collector_pipelines');"
 
-"/var/vcap/jobs/database-backup-restorer/bin/backup" --config "${CONFIG_PATH}" --artifact-file "${BBR_ARTIFACT_FILE_PATH}"
+function unpause() {
+  "/var/vcap/packages/database-backup-restorer-postgres-11/bin/psql" "${PG_CONNECTION_STRING}" -c "${UNPAUSE_WEB_COMPONENTS}"
+}
+
+# paused all concourse components to ensure bbr success
+"/var/vcap/packages/database-backup-restorer-postgres-11/bin/psql" "${PG_CONNECTION_STRING}" -c "${PAUSE_WEB_COMPONENTS}"
+# unpause all concourse components to after bbr finishes
+trap unpause EXIT
+sleep 30
+
+ticks=0
+
+until "/var/vcap/jobs/database-backup-restorer/bin/backup" --config "${CONFIG_PATH}" --artifact-file "${BBR_ARTIFACT_FILE_PATH}"; do
+  ((ticks++))
+
+  if [[ $ticks -ge 3 ]]; then
+    echo "Backup failed three times. Giving up."
+    exit 1
+  fi
+
+  echo "backup failed. Trying again in 10s"
+  sleep 10
+done

--- a/jobs/bbr-atcdb/templates/config.json.erb.tmpl
+++ b/jobs/bbr-atcdb/templates/config.json.erb.tmpl
@@ -1,0 +1,21 @@
+{{template "postgres_config.erb.tmpl" .}}
+
+<%=
+  config_data = {
+    'username' => postgres_role_name,
+    'password' => postgres_role_password,
+    'host' => postgres_host,
+    'port' => postgres_port,
+    'database' => postgres_database,
+    'adapter' => 'postgres'
+  }
+
+  if postgres_tls_enabled
+    config_data['tls.skip_host_verify'] = postgres_tls_skip_host_verify
+    config_data['tls.cert.ca'] = postgres_tls_ca
+    config_data['tls.cert.certificate'] = postgres_tls_public_cert
+    config_data['tls.cert.private_key'] = postgres_tls_private_key
+  end
+
+  JSON.pretty_generate(config_data)
+%>

--- a/jobs/bbr-atcdb/templates/connection_data.erb
+++ b/jobs/bbr-atcdb/templates/connection_data.erb
@@ -1,3 +1,51 @@
+#!/bin/bash
+# vim: ft=sh
+
+set -e -u -x
+
+ENV_FILE_OWNER=vcap
+
+mkdir -p /var/vcap/jobs/bbr-atcdb/config/env
+
+<%
+  # vim: ft=eruby
+
+  def env_file_perms(fn)
+    <<~EOS
+      if [[ "${ENV_FILE_OWNER:-}" != "" ]] ; then
+        chown ${ENV_FILE_OWNER}:${ENV_FILE_OWNER} #{fn}
+      fi
+      chmod 0600 #{fn}
+    EOS
+  end
+
+  def env_file_content(v)
+    case v
+    when Array
+      v.collect(&:chomp).join("\n").chomp + "\n"
+    when String
+      v.chomp + "\n"
+    else
+      v.to_json + "\n"
+    end
+  end
+
+  def env_file_writer(v, env)
+    path = "/var/vcap/jobs/bbr-atcdb/config/env/#{env}"
+
+    case v
+    when Hash
+      v.collect do |k, v|
+        fn = "#{path}_#{k}"
+        "cat > #{fn} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(fn)}"
+      end.join("\n\n")
+    else
+      "cat > #{path} <<\"ENVGEN_EOF\"\n#{env_file_content(v)}ENVGEN_EOF\n#{env_file_perms(path)}"
+    end
+  end
+-%>
+
+
 <%
     require 'json'
 
@@ -85,7 +133,7 @@
       postgres_tls_enabled = cdb.p("postgresql.sslmode", postgres_tls_enabled)
       if postgres_tls_enabled
         if postgres_tls_ca.empty?
-          postgres_tls_ca = cdb.p("postgresql.ca_cert")
+          postgres_tls_ca = cdb.p("postgresql.ca_cert.ca")
         end
 
         if postgres_tls_public_cert.empty?
@@ -97,25 +145,44 @@
         end
       end
     end
-%>
+-%>
 
 
-<%=
-  config_data = {
-    'username' => postgres_role_name,
-    'password' => postgres_role_password,
-    'host' => postgres_host,
-    'port' => postgres_port,
-    'database' => postgres_database,
-    'adapter' => 'postgres'
-  }
+<%
+  connection_string = "host="+postgres_host \
+    +" user="+postgres_role_name \
+    +" password="+postgres_role_password \
+    +" port="+postgres_port.to_s() \
+    +" dbname="+postgres_database
 
-  if postgres_tls_enabled
-    config_data['tls.skip_host_verify'] = postgres_tls_skip_host_verify
-    config_data['tls.cert.ca'] = postgres_tls_ca
-    config_data['tls.cert.certificate'] = postgres_tls_public_cert
-    config_data['tls.cert.private_key'] = postgres_tls_private_key
-  end
+    sslmode = "disable"
 
-  JSON.pretty_generate(config_data)
-%>
+    unless postgres_tls_skip_host_verify
+      sslmode = "require"
+
+      unless postgres_tls_ca.empty?
+-%>
+<%=        env_file_writer(postgres_tls_ca, "POSTGRES_TLS_CA") %>
+<%
+        connection_string += " sslrootcert=/var/vcap/jobs/bbr-atcdb/config/env/POSTGRES_TLS_CA"
+      end
+
+      unless postgres_tls_public_cert.empty?
+-%>
+<%=        env_file_writer(postgres_tls_public_cert, "POSTGRES_TLS_CERTIFICATE") %>
+<%
+        connection_string += " sslcert=/var/vcap/jobs/bbr-atcdb/config/env/POSTGRES_TLS_CERTIFICATE"
+      end
+
+      unless postgres_tls_private_key.empty?
+-%>
+<%=        env_file_writer(postgres_tls_private_key, "POSTGRES_TLS_PRIVATE_KEY") %>
+<%
+        connection_string += " sslkey=/var/vcap/jobs/bbr-atcdb/config/env/POSTGRES_TLS_PRIVATE_KEY"
+      end
+    end
+
+    connection_string += " sslmode="+sslmode
+-%>
+
+<%= "PG_CONNECTION_STRING=\""+connection_string+"\"" %>

--- a/jobs/bbr-atcdb/templates/connection_data.erb.tmpl
+++ b/jobs/bbr-atcdb/templates/connection_data.erb.tmpl
@@ -1,0 +1,42 @@
+#!/bin/bash
+# vim: ft=sh
+
+set -e -u -x
+
+ENV_FILE_OWNER=vcap
+
+{{template "create_env_files.erb.tmpl" .}}
+{{template "postgres_config.erb.tmpl" .}}
+
+<%=
+  connection_string = "host="+postgres_host \
+    +" user="+postgres_role_name \
+    +" password="+postgres_role_password \
+    +" port="+postgres_port.to_s() \
+    +" dbname="+postgres_database
+
+    sslmode = "disable"
+
+    unless postgres_tls_skip_host_verify
+      sslmode = "require"
+
+      unless postgres_tls_ca.empty?
+        env_file_writer(postgres_tls_ca, "CONCOURSE_TLS_CA")
+        connection_string += " sslrootcert=/var/vcap/jobs/bbr-atcdb/config/env/CONCOURSE_TLS_CA" \
+      end
+
+      unless postgres_tls_public_cert.empty?
+        env_file_writer(postgres_tls_public_cert, "CONCOURSE_TLS_CERTIFICATE")
+        connection_string += " sslcert=/var/vcap/jobs/bbr-atcdb/config/env/CONCOURSE_TLS_CERTIFICATE" \
+      end
+
+      unless postgres_tls_private_key.empty?
+        env_file_writer(postgres_tls_private_key, "CONCOURSE_TLS_PRIVATE_KEY")
+        connection_string += " sslkey=/var/vcap/jobs/bbr-atcdb/config/env/CONCOURSE_TLS_PRIVATE_KEY"
+      end
+    end
+
+    connection_string += " sslmode="+sslmode
+
+    puts "PG_CONNECTION_STRING=\""+connection_string+"\""
+%>

--- a/tmpl/postgres_config.erb.tmpl
+++ b/tmpl/postgres_config.erb.tmpl
@@ -98,24 +98,3 @@
       end
     end
 %>
-
-
-<%=
-  config_data = {
-    'username' => postgres_role_name,
-    'password' => postgres_role_password,
-    'host' => postgres_host,
-    'port' => postgres_port,
-    'database' => postgres_database,
-    'adapter' => 'postgres'
-  }
-
-  if postgres_tls_enabled
-    config_data['tls.skip_host_verify'] = postgres_tls_skip_host_verify
-    config_data['tls.cert.ca'] = postgres_tls_ca
-    config_data['tls.cert.certificate'] = postgres_tls_public_cert
-    config_data['tls.cert.private_key'] = postgres_tls_private_key
-  end
-
-  JSON.pretty_generate(config_data)
-%>


### PR DESCRIPTION
fixes concourse/concourse#6588

This PR does two things:
1. Pause the tracker and collector_pipelines components to reduce the
   chance of a build finishing while pg_dump is running. Sleep after
   pausing the components as well just to be extra safe.
2. Call the bbr backup binary up to three times if it fails. Most likely
   cause of failure based on support tickets has been a build
   finishing and its sequence table being dropped. We think it's
   unlikely for this to be the cause three times in a row within 10s of
   each other.

CC @xtremerui 