### PR TITLE
Add Content-Security-Policy header to web

### DIFF
--- a/jobs/bbr-atcdb/templates/connection_data.erb.tmpl
+++ b/jobs/bbr-atcdb/templates/connection_data.erb.tmpl
@@ -44,12 +44,12 @@ ENV_FILE_OWNER=vcap
       unless postgres_tls_private_key.empty?
 -%>
 <%=     env_file_writer(postgres_tls_private_key, "CONCOURSE_TLS_PRIVATE_KEY") %>
-<%=
+<%
         connection_string += " sslkey=/var/vcap/jobs/bbr-atcdb/config/env/CONCOURSE_TLS_PRIVATE_KEY"
       end
     end
 
     connection_string += " sslmode="+sslmode
+-%>
 
-    puts "PG_CONNECTION_STRING=\""+connection_string+"\""
-%>
+<%= "PG_CONNECTION_STRING=\""+connection_string+"\"" %>

--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -120,8 +120,14 @@ properties:
   x_frame_options:
     env: CONCOURSE_X_FRAME_OPTIONS
     description: |
-      The value to set for X-Frame-Options.
-    default: deny
+      The value to set for X-Frame-Options header.
+    example: deny
+
+  content_security_policy:
+    env: CONCOURSE_CONTENT_SECURITY_POLICY
+    description: |
+      The value to set for Content-Security-Policy header.
+    example: "no-store, private"
 
   concurrent_request_limits:
     env: CONCOURSE_CONCURRENT_REQUEST_LIMIT

--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -331,6 +331,10 @@ processes:
     CONCOURSE_CONTAINER_PLACEMENT_STRATEGY: <%= env_flag(v).to_json %>
 <% end -%>
 
+<% if_p("content_security_policy") do |v| -%>
+    CONCOURSE_CONTENT_SECURITY_POLICY: <%= env_flag(v).to_json %>
+<% end -%>
+
 <% if_p("cookie_secure") do |v| -%>
     CONCOURSE_COOKIE_SECURE: <%= env_flag(v).to_json %>
 <% end -%>


### PR DESCRIPTION
Add the CSP flag from concourse/concourse#6949

Also changed `x_frame_options` to not have a default to ensure it uses the default set in the Concourse binary.

Sneaking in an extra change to fix an issue with the bbr job templates being out of sync. Noticed it when I ran the `generate-job-templates` script.