### PR TITLE
Remove systemd process number limit

### DIFF
--- a/jobs/worker/templates/concourse.service
+++ b/jobs/worker/templates/concourse.service
@@ -7,3 +7,4 @@ ExecStart=/var/vcap/jobs/worker/bin/concourse_start
 ExecStop=/var/vcap/jobs/worker/bin/concourse_stop
 Delegate=yes
 KillMode=none
+TasksMax=infinity


### PR DESCRIPTION
The bionic stemcell contains systemd v237 which by default gives a limit of 4915 processes to system cgroups. This restriction can cause jobs to fail when under load. So we are reverting to the xenial default of pids.max = max.

We are seeing this pipeline where we have many periodic jobs running at the same time. The limit gets gets exhausted fairly quickly causing random jobs to fail. We have hit this same problem on garden a few months ago. You can find more info on that in [this pivotal tracker story](https://www.pivotaltracker.com/n/projects/1158420/stories/176595591) and [this commit in our bosh release](https://github.com/cloudfoundry/garden-runc-release/commit/8dec786a6bbe25f6ed8910e910b9799fafad1a61). SSH-ing on the concourse worker we can see that the `garden.system` cgroup has `pids.max` set to `max`, but since it is a child cgroup of `concourse.system` and that has it's pid.max set to the default of 4915, it gets limited too.