### PR TITLE
Change metric attribute - to _ for prometheus compatibility

### DIFF
--- a/jobs/web/templates/bpm.yml.erb
+++ b/jobs/web/templates/bpm.yml.erb
@@ -19,7 +19,7 @@ processes:
 -%>
     CONCOURSE_PEER_ADDRESS: <%= peer_address %>
 
-    CONCOURSE_METRICS_ATTRIBUTE: <%= "bosh-deployment:#{spec.deployment},bosh-job:#{name}".to_json %>
+    CONCOURSE_METRICS_ATTRIBUTE: <%= "bosh_deployment:#{spec.deployment},bosh_job:#{name}".to_json %>
 
 <%
   if_link("web") do |l|

--- a/jobs/web/templates/bpm.yml.erb.tmpl
+++ b/jobs/web/templates/bpm.yml.erb.tmpl
@@ -19,7 +19,7 @@ processes:
 -%>
     CONCOURSE_PEER_ADDRESS: <%= peer_address %>
 
-    CONCOURSE_METRICS_ATTRIBUTE: <%= "bosh-deployment:#{spec.deployment},bosh-job:#{name}".to_json %>
+    CONCOURSE_METRICS_ATTRIBUTE: <%= "bosh_deployment:#{spec.deployment},bosh_job:#{name}".to_json %>
 
 <%
   if_link("web") do |l|


### PR DESCRIPTION
The "bosh-deployment" attribute breaks with later Prometheus  libraries since dash (-) is not valid attribute character.