### PR TITLE
add worker containerd config

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -306,6 +306,16 @@ properties:
       Path to an init executable. For BOSH this defaults to /var/vcap/packages/concourse/bin/init when containerd
       is selected as the runtime.
 
+  containerd.oci_hooks_dir:
+    env: CONCOURSE_CONTAINERD_OCI_HOOKS_DIR
+    description: |
+      Path to the oci hooks dir. By default none is provided.
+
+  containerd.seccomp_profile:
+    env: CONCOURSE_CONTAINERD_SECCOMP_PROFILE
+    description: |
+      Path to a seccomp filter override. By default will use a restrictive default set.
+
   containerd.cni_bin:
     env: CONCOURSE_CONTAINERD_CNI_PLUGINS_DIR
     description: |

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -138,6 +138,14 @@ export CONCOURSE_CONTAINERD_EXTERNAL_IP=<%= esc(env_flag(v)) %>
 export CONCOURSE_CONTAINERD_INIT_BIN=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("containerd.oci_hooks_dir") do |v| -%>
+export CONCOURSE_CONTAINERD_OCI_HOOKS_DIR=<%= esc(env_flag(v)) %>
+<% end -%>
+
+<% if_p("containerd.seccomp_profile") do |v| -%>
+export CONCOURSE_CONTAINERD_SECCOMP_PROFILE=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("containerd.max_containers") do |v| -%>
 export CONCOURSE_CONTAINERD_MAX_CONTAINERS=<%= esc(env_flag(v)) %>
 <% end -%>


### PR DESCRIPTION
for oci_hooks_dir and seccomp_profile

refer to https://github.com/concourse/concourse/pull/8044