### PR TITLE
Removing default value, as to use the one from the source-code

### DIFF
--- a/jobs/web/spec
+++ b/jobs/web/spec
@@ -1099,7 +1099,6 @@ properties:
     env: CONCOURSE_GC_CHECK_RECYCLE_PERIOD
     description: |
       Period after which finished checks will get garbage-collected.
-    default: 6h
 
   gc.failed_grace_period:
     env: CONCOURSE_GC_FAILED_GRACE_PERIOD


### PR DESCRIPTION
References:
- https://github.com/concourse/concourse/issues/5157
- https://github.com/concourse/concourse/pull/5168

As per the above mentioned PR's it looks like, we forgot to adjust the default value for the checks recycle, meaning that for bosh Concourses, the checks will pile up. Let's remove the default value from this spec and use the default from Concourse source code, if not otherwise specified here.