### PR TITLE
Additional hosts support in Concourse Bosh Release

### DIFF
--- a/jobs/worker/spec
+++ b/jobs/worker/spec
@@ -280,6 +280,14 @@ properties:
     description: |
       List of network ranges to which traffic from containers will be restricted.
 
+  containerd.additional_hosts:
+    env: CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS
+    description: |
+      List of hosts to be added to /etc/hosts file.
+      Example:
+        - 1.1.1.1 example.com
+        - 2.2.2.2 another.example.com
+
   containerd.allow_host_access:
     env: CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS
     description: |

--- a/jobs/worker/templates/env.sh.erb
+++ b/jobs/worker/templates/env.sh.erb
@@ -178,6 +178,10 @@ export CONCOURSE_CONTAINERD_REQUEST_TIMEOUT=<%= esc(env_flag(v)) %>
 export CONCOURSE_CONTAINERD_RESTRICTED_NETWORK=<%= esc(env_flag(v)) %>
 <% end -%>
 
+<% if_p("containerd.additional_hosts") do |v| -%>
+export CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS=<%= esc(env_flag(v)) %>
+<% end -%>
+
 <% if_p("containerd.seccomp_profile") do |v| -%>
 export CONCOURSE_CONTAINERD_SECCOMP_PROFILE=<%= esc(env_flag(v)) %>
 <% end -%>


### PR DESCRIPTION
# Why do we need this PR?
Because of upstream change - https://github.com/concourse/concourse/pull/9238


# Changes proposed in this pull request
*  support for additional dns hosts in `/etc/hosts` of the container when using `containerd` runtime.

